### PR TITLE
GH Actions: conditionally deploy API and Runner only when affected on push (plus manual dispatch)

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -1,6 +1,9 @@
 name: Deploy API
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       environment:
@@ -38,7 +41,46 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Determine API Deploy Scope
+        id: deploy-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          MANUAL_DEPLOY_ENV: ${{ github.event.inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            echo 'should_deploy=true' >> "$GITHUB_OUTPUT"
+            echo "deploy_env=${MANUAL_DEPLOY_ENV}" >> "$GITHUB_OUTPUT"
+            echo 'affected_projects=["api"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE_REF="$BASE_SHA"
+          if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="$(git rev-parse "${HEAD_SHA}^")"
+          fi
+
+          AFFECTED_PROJECTS="$(pnpm exec nx show projects --affected --base="$BASE_REF" --head="$HEAD_SHA" --projects=api --json)"
+
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo 'deploy_env=production' >> "$GITHUB_OUTPUT"
+          echo "affected_projects=$AFFECTED_PROJECTS" >> "$GITHUB_OUTPUT"
+
+          if [ "$AFFECTED_PROJECTS" = '["api"]' ]; then
+            echo 'should_deploy=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'should_deploy=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip API Deploy
+        if: ${{ github.event_name == 'push' && steps.deploy-scope.outputs.should_deploy != 'true' }}
+        run: echo "Skipping API deploy because api is not affected for ${{ github.sha }}."
+
       - name: Configure AWS Credentials
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -46,13 +88,15 @@ jobs:
           aws-region: eu-central-1
 
       - name: Login to Amazon ECR
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Publish and Deploy API
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          DEPLOY_ENV: ${{ github.event.inputs.environment }}
+          DEPLOY_ENV: ${{ steps.deploy-scope.outputs.deploy_env }}
         run: |
           if [ "$DEPLOY_ENV" = "production" ]; then
             IMAGE_REF="${ECR_REGISTRY}/app-speed/api:${GITHUB_SHA::12}"

--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -1,6 +1,9 @@
 name: Deploy Runner
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       environment:
@@ -42,7 +45,46 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Determine Runner Deploy Scope
+        id: deploy-scope
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+          MANUAL_DEPLOY_ENV: ${{ github.event.inputs.environment }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            echo 'should_deploy=true' >> "$GITHUB_OUTPUT"
+            echo "deploy_env=${MANUAL_DEPLOY_ENV}" >> "$GITHUB_OUTPUT"
+            echo 'affected_projects=["runner"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          BASE_REF="$BASE_SHA"
+          if [ -z "$BASE_REF" ] || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            BASE_REF="$(git rev-parse "${HEAD_SHA}^")"
+          fi
+
+          AFFECTED_PROJECTS="$(pnpm exec nx show projects --affected --base="$BASE_REF" --head="$HEAD_SHA" --projects=runner --json)"
+
+          echo "base_ref=$BASE_REF" >> "$GITHUB_OUTPUT"
+          echo 'deploy_env=production' >> "$GITHUB_OUTPUT"
+          echo "affected_projects=$AFFECTED_PROJECTS" >> "$GITHUB_OUTPUT"
+
+          if [ "$AFFECTED_PROJECTS" = '["runner"]' ]; then
+            echo 'should_deploy=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'should_deploy=false' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip Runner Deploy
+        if: ${{ github.event_name == 'push' && steps.deploy-scope.outputs.should_deploy != 'true' }}
+        run: echo "Skipping runner deploy because runner is not affected for ${{ github.sha }}."
+
       - name: Configure AWS Credentials
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -50,13 +92,15 @@ jobs:
           aws-region: eu-central-1
 
       - name: Login to Amazon ECR
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Publish and Deploy Runner
+        if: ${{ steps.deploy-scope.outputs.should_deploy == 'true' }}
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          DEPLOY_ENV: ${{ github.event.inputs.environment }}
+          DEPLOY_ENV: ${{ steps.deploy-scope.outputs.deploy_env }}
         run: |
           RUN_SUFFIX="${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           if [ "$DEPLOY_ENV" = "production" ]; then


### PR DESCRIPTION
### Motivation

- Reduce unnecessary deploys by running API and Runner deployment jobs only when their projects are affected on `push` to `main`.
- Preserve manual `workflow_dispatch` behavior so a manual deploy can still target `development` or `production` regardless of affected files.
- Standardize detection of affected projects using the existing monorepo tooling to avoid wasted CI and cloud operations.

### Description

- Added `push` trigger for `main` branch to both `.github/workflows/deploy-api.yml` and `.github/workflows/deploy-runner.yml` so pushes can auto-deploy when relevant.
- Introduced a `Determine ... Deploy Scope` step that computes `should_deploy`, `deploy_env`, and `affected_projects` using `pnpm exec nx show projects --affected` and sets outputs via `GITHUB_OUTPUT` for both workflows.
- Added conditional `Skip ... Deploy` step and gated the AWS credential, ECR login, and publish/deploy steps with `if: steps.deploy-scope.outputs.should_deploy == 'true'` to avoid running deploy steps when the target project is not affected.
- Updated `DEPLOY_ENV` value to come from `steps.deploy-scope.outputs.deploy_env` (instead of `github.event.inputs.environment`) and ensure manual dispatch still forces `should_deploy=true` and the requested environment.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bed2b942e0833186a326ce3a840a82)