### PR TITLE
docs(readme): add centered logo at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="apps/portal/src/assets/logo.svg" alt="AppSpeed logo" width="120" />
+</p>
+
 # AppSpeed
 
 AppSpeed runs Lighthouse user-flow audits in a stable environment.


### PR DESCRIPTION
### Motivation
- Add a centered project logo to the top of the repository `README.md` to provide immediate branding and reuse the existing portal asset at `apps/portal/src/assets`.

### Description
- Inserted an HTML block at the top of `README.md` with `<p align="center">` and an `<img>` referencing `apps/portal/src/assets/logo.svg` with `width="120"`.

### Testing
- Ran `git diff -- README.md`, `git status --short`, and committed the change; this is a documentation-only change and no automated project tests were executed or affected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74aefe63883318c04619fdd271ba4)