### PR TITLE
refactor(audit-domain): restructure custom step schema

### DIFF
--- a/libs/audit/api-contract/src/lib/audit/builder/Api.ts
+++ b/libs/audit/api-contract/src/lib/audit/builder/Api.ts
@@ -2,10 +2,10 @@ import { HttpApiEndpoint, HttpApiError, HttpApiSchema } from '@effect/platform';
 import { Schema } from 'effect';
 
 import { AuditId, AuditNotFoundError, AuditRunStatusSchema } from '../Audit';
-import { AuditAuthoringSchema } from '@app-speed/audit/domain';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 export const scheduleEndpoint = HttpApiEndpoint.post('schedule', '/schedule')
-  .setPayload(AuditAuthoringSchema)
+  .setPayload(AuditSchema)
   .addSuccess(
     Schema.Struct({
       auditId: Schema.String,

--- a/libs/audit/api-contract/src/lib/audit/builder/Api.ts
+++ b/libs/audit/api-contract/src/lib/audit/builder/Api.ts
@@ -2,10 +2,10 @@ import { HttpApiEndpoint, HttpApiError, HttpApiSchema } from '@effect/platform';
 import { Schema } from 'effect';
 
 import { AuditId, AuditNotFoundError, AuditRunStatusSchema } from '../Audit';
-import { ReplayUserflowAuditSchema } from '@app-speed/audit/domain';
+import { AuditAuthoringSchema } from '@app-speed/audit/domain';
 
 export const scheduleEndpoint = HttpApiEndpoint.post('schedule', '/schedule')
-  .setPayload(ReplayUserflowAuditSchema)
+  .setPayload(AuditAuthoringSchema)
   .addSuccess(
     Schema.Struct({
       auditId: Schema.String,

--- a/libs/audit/api-contract/src/lib/runner/Api.ts
+++ b/libs/audit/api-contract/src/lib/runner/Api.ts
@@ -1,7 +1,7 @@
 import { HttpApiEndpoint, HttpApiError, HttpApiGroup } from '@effect/platform';
 import { Schema } from 'effect';
 
-import { ReplayUserflowAuditSchema } from '@app-speed/audit/domain';
+import { AuditAuthoringSchema } from '@app-speed/audit/domain';
 
 import { AuditErrorSchema, AuditId, AuditResultStatusSchema } from '../audit/Audit';
 
@@ -18,7 +18,7 @@ const RunnerClaimResponseSchema = Schema.Union(
   Schema.Struct({
     available: Schema.Literal(true),
     auditId: AuditId,
-    auditDetails: ReplayUserflowAuditSchema,
+    auditDetails: AuditAuthoringSchema,
   }),
 );
 

--- a/libs/audit/api-contract/src/lib/runner/Api.ts
+++ b/libs/audit/api-contract/src/lib/runner/Api.ts
@@ -1,7 +1,7 @@
 import { HttpApiEndpoint, HttpApiError, HttpApiGroup } from '@effect/platform';
 import { Schema } from 'effect';
 
-import { AuditAuthoringSchema } from '@app-speed/audit/domain';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 import { AuditErrorSchema, AuditId, AuditResultStatusSchema } from '../audit/Audit';
 
@@ -18,7 +18,7 @@ const RunnerClaimResponseSchema = Schema.Union(
   Schema.Struct({
     available: Schema.Literal(true),
     auditId: AuditId,
-    auditDetails: AuditAuthoringSchema,
+    auditDetails: AuditSchema,
   }),
 );
 

--- a/libs/audit/domain/src/index.ts
+++ b/libs/audit/domain/src/index.ts
@@ -1,8 +1,8 @@
 export {
   AuditStep,
   PuppeteerReplayUserflowRunnerSchema,
-  ReplayUserflowAudit,
-  ReplayUserflowAuditSchema,
+  AuditAuthoring,
+  AuditAuthoringSchema,
 } from './lib/audit.schema';
 export { STEP_TYPE, StepType } from './lib/step-type';
 export { AppSpeedUserFlow } from './lib/runtime/replay';
@@ -13,6 +13,8 @@ export {
   isReplayUserflowStep,
   ReplayUserflowStepSchema,
   UserflowAuditStepTypeScheme,
+  UserflowRunnerStepSchema,
+  UserflowStepSchema,
   UserflowStepTypeWithStepFlagsLiteral,
   UserflowStepTypeWithoutStepFlagsLiteral,
 } from './lib/lighthouse-userflow/lighthouse-userflow-step';

--- a/libs/audit/domain/src/index.ts
+++ b/libs/audit/domain/src/index.ts
@@ -1,9 +1,4 @@
-export {
-  AuditStep,
-  PuppeteerReplayUserflowRunnerSchema,
-  AuditAuthoring,
-  AuditAuthoringSchema,
-} from './lib/audit.schema';
+export { AuditStep, PuppeteerReplayUserflowRunnerSchema, Audit, AuditSchema } from './lib/audit.schema';
 export { STEP_TYPE, StepType } from './lib/step-type';
 export { AppSpeedUserFlow } from './lib/runtime/replay';
 export { DEVICE_TYPE, DeviceType, DEVICE_OPTIONS, DeviceSchema } from './lib/shared/device-type';

--- a/libs/audit/domain/src/lib/audit-step.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit-step.schema.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { Schema, Either, ParseResult } from 'effect';
 import { AuditStepSchema, AuditStepTypeSchema, isAuditStep, isStepType } from './audit-step.schema';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
+import { PUPPETEER_REPLAY_CUSTOM_STEP_TYPE } from './puppeteer-replay/puppeteer-replay-step-type';
 
 describe('AuditStep', () => {
   it('should reject with readable message invalid step type', () => {
@@ -11,7 +12,28 @@ describe('AuditStep', () => {
     expect(decodingErrorMessage(AuditStepTypeSchema, 'INVALID_TYPE_STUB')).toContain('Invalid audit step type');
   });
 
-  it.for(Object.values(LIGHTHOUSE_AUDIT_STEP_TYPE))('should accept valid step type %s', (type) => {
+  it('should accept replay customStep as a valid step type', () => {
+    expect(isStepType(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)).toEqual(true);
+  });
+
+  it.for(Object.values(LIGHTHOUSE_AUDIT_STEP_TYPE))('should reject custom step identities as top-level step types: %s', (type) => {
+    expect(isStepType(type)).toEqual(false);
+  });
+
+  it('should accept custom steps when they include an explicit step discriminant', () => {
+    expect(
+      isAuditStep({
+        type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      }),
+    ).toEqual(true);
+  });
+
+  it('should reject custom steps without a custom step identity', () => {
+    expect(isAuditStep({ type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP })).toEqual(false);
+  });
+
+  it.for(['navigate', 'waitForElement'])('should accept valid non-custom step type %s', (type) => {
     expect(isStepType(type)).toEqual(true);
   });
 

--- a/libs/audit/domain/src/lib/audit-step.schema.ts
+++ b/libs/audit/domain/src/lib/audit-step.schema.ts
@@ -10,7 +10,6 @@ const PuppeteerReplayStepTypeSchema = Schema.Literal(
   PUPPETEER_REPLAY_USER_STEP_TYPE.CHANGE,
   PUPPETEER_REPLAY_USER_STEP_TYPE.CLICK,
   PUPPETEER_REPLAY_USER_STEP_TYPE.CLOSE,
-  PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
   PUPPETEER_REPLAY_USER_STEP_TYPE.DOUBLE_CLICK,
   PUPPETEER_REPLAY_USER_STEP_TYPE.EMULATE_NETWORK_CONDITIONS,
   PUPPETEER_REPLAY_USER_STEP_TYPE.HOVER,
@@ -23,7 +22,7 @@ const PuppeteerReplayStepTypeSchema = Schema.Literal(
   PUPPETEER_REPLAY_ASSERTION_STEP_TYPE.WAIT_FOR_EXPRESSION,
 );
 
-const LighthouseUserflowStepTypeSchema = Schema.Literal(
+export const AuditCustomStepTypeSchema = Schema.Literal(
   LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
   LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
   LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
@@ -33,7 +32,7 @@ const LighthouseUserflowStepTypeSchema = Schema.Literal(
 
 export const AuditStepTypeSchema = Schema.Union(
   PuppeteerReplayStepTypeSchema,
-  LighthouseUserflowStepTypeSchema,
+  Schema.Literal(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP),
 ).annotations({
   identifier: 'AuditStepType',
   parseIssueTitle: ({ actual }) => `Invalid audit step type: ${actual || null} is not supported`,
@@ -42,8 +41,12 @@ export const AuditStepTypeSchema = Schema.Union(
 
 export const isStepType = Schema.is(AuditStepTypeSchema);
 
-export const AuditStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema,
+const ReplayAuditStepSchema = Schema.Struct({ type: PuppeteerReplayStepTypeSchema });
+const CustomAuditStepSchema = Schema.Struct({
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema,
 });
+
+export const AuditStepSchema = Schema.Union(ReplayAuditStepSchema, CustomAuditStepSchema);
 
 export const isAuditStep = Schema.is(AuditStepSchema);

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -4,7 +4,7 @@ import { it } from '@effect/vitest';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
 import { AuditSchema, PuppeteerReplayUserflowRunnerSchema } from './audit.schema';
 
-describe('ReplayRunnerSchema', () => {
+describe('PuppeteerReplayUserflowRunnerSchema', () => {
   it('should decode to replay schema', () => {
     const recording = {
       title: 'Stub audit title',

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -2,7 +2,7 @@ import { Schema } from 'effect';
 import { describe } from 'vitest';
 import { it } from '@effect/vitest';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
-import { PuppeteerReplayUserflowRunnerSchema, ReplayUserflowAuditSchema } from './audit.schema';
+import { AuditAuthoringSchema, PuppeteerReplayUserflowRunnerSchema } from './audit.schema';
 
 describe('ReplayRunnerSchema', () => {
   it('should decode to replay schema', () => {
@@ -11,7 +11,8 @@ describe('ReplayRunnerSchema', () => {
       device: 'mobile',
       steps: [
         {
-          type: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+          type: 'customStep',
+          step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
           name: 'Home Page',
         },
       ],
@@ -31,36 +32,53 @@ describe('ReplayRunnerSchema', () => {
   });
 });
 
-describe('ReplayUserflowAuditSchema', () => {
+describe('AuditAuthoringSchema', () => {
   it('should accept valid audit', async () => {
     expect(
-      Schema.is(ReplayUserflowAuditSchema)({
+      Schema.is(AuditAuthoringSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [
           {
-            type: 'endNavigation',
+            type: 'customStep',
+            step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
           },
         ],
       }),
     ).toBe(true);
   });
 
+  it('should reject replay-shaped custom step input', () => {
+    expect(
+      Schema.is(AuditAuthoringSchema)({
+        title: 'Stub audit title',
+        device: 'mobile',
+        steps: [
+          {
+            type: 'customStep',
+            name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+            parameters: { name: 'Home Page' },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
   it('should reject empty object', () => {
-    expect(Schema.is(ReplayUserflowAuditSchema)({})).toBe(false);
+    expect(Schema.is(AuditAuthoringSchema)({})).toBe(false);
   });
 
   it('should reject missing device', () => {
-    expect(Schema.is(ReplayUserflowAuditSchema)({ title: '' })).toBe(false);
+    expect(Schema.is(AuditAuthoringSchema)({ title: '' })).toBe(false);
   });
 
   it('should reject missing title', () => {
-    expect(Schema.is(ReplayUserflowAuditSchema)({ device: '' })).toBe(false);
+    expect(Schema.is(AuditAuthoringSchema)({ device: '' })).toBe(false);
   });
 
   it('should reject invalid timeout', () => {
     expect(
-      Schema.is(ReplayUserflowAuditSchema)({
+      Schema.is(AuditAuthoringSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         timeout: -1,
@@ -72,14 +90,14 @@ describe('ReplayUserflowAuditSchema', () => {
 
   it('should reject no steps', () => {
     expect(
-      Schema.is(ReplayUserflowAuditSchema)({
+      Schema.is(AuditAuthoringSchema)({
         title: 'Stub audit title',
         device: 'mobile',
       }),
     ).toBe(false);
 
     expect(
-      Schema.is(ReplayUserflowAuditSchema)({
+      Schema.is(AuditAuthoringSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [],
@@ -89,7 +107,7 @@ describe('ReplayUserflowAuditSchema', () => {
 
   it('should reject if no audit step in steps', () => {
     expect(
-      Schema.is(ReplayUserflowAuditSchema)({
+      Schema.is(AuditAuthoringSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -2,7 +2,7 @@ import { Schema } from 'effect';
 import { describe } from 'vitest';
 import { it } from '@effect/vitest';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
-import { AuditAuthoringSchema, PuppeteerReplayUserflowRunnerSchema } from './audit.schema';
+import { AuditSchema, PuppeteerReplayUserflowRunnerSchema } from './audit.schema';
 
 describe('ReplayRunnerSchema', () => {
   it('should decode to replay schema', () => {
@@ -32,10 +32,10 @@ describe('ReplayRunnerSchema', () => {
   });
 });
 
-describe('AuditAuthoringSchema', () => {
+describe('AuditSchema', () => {
   it('should accept valid audit', async () => {
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [
@@ -50,7 +50,7 @@ describe('AuditAuthoringSchema', () => {
 
   it('should reject replay-shaped custom step input', () => {
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [
@@ -65,20 +65,20 @@ describe('AuditAuthoringSchema', () => {
   });
 
   it('should reject empty object', () => {
-    expect(Schema.is(AuditAuthoringSchema)({})).toBe(false);
+    expect(Schema.is(AuditSchema)({})).toBe(false);
   });
 
   it('should reject missing device', () => {
-    expect(Schema.is(AuditAuthoringSchema)({ title: '' })).toBe(false);
+    expect(Schema.is(AuditSchema)({ title: '' })).toBe(false);
   });
 
   it('should reject missing title', () => {
-    expect(Schema.is(AuditAuthoringSchema)({ device: '' })).toBe(false);
+    expect(Schema.is(AuditSchema)({ device: '' })).toBe(false);
   });
 
   it('should reject invalid timeout', () => {
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         timeout: -1,
@@ -90,14 +90,14 @@ describe('AuditAuthoringSchema', () => {
 
   it('should reject no steps', () => {
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
       }),
     ).toBe(false);
 
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [],
@@ -107,7 +107,7 @@ describe('AuditAuthoringSchema', () => {
 
   it('should reject if no audit step in steps', () => {
     expect(
-      Schema.is(AuditAuthoringSchema)({
+      Schema.is(AuditSchema)({
         title: 'Stub audit title',
         device: 'mobile',
         steps: [

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -59,7 +59,8 @@ const AuditStepsSchema = Schema.NonEmptyArray(AuditAuthoringStepSchema);
 const RunnerStepsSchema = Schema.NonEmptyArray(RunnerStepSchema);
 
 const RequiresAuditStepSchemaFilter = Schema.filter<typeof AuditStepsSchema>(
-  (steps) => !!steps.filter((step) => Schema.is(UserflowStepSchema)(step)).length || 'Requires at least one audit steps',
+  (steps) =>
+    !!steps.filter((step) => Schema.is(UserflowStepSchema)(step)).length || 'Requires at least one audit steps',
 );
 
 const NonNegativeIntFromStringSchema = Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative()).annotations({
@@ -72,21 +73,21 @@ const TimeoutSchema = Schema.optional(
   }),
 );
 
-export const AuditAuthoringSchema = Schema.Struct({
+export const AuditSchema = Schema.Struct({
   title: Schema.NonEmptyString,
   device: DeviceSchema,
   timeout: TimeoutSchema,
   steps: Schema.NonEmptyArray(AuditAuthoringStepSchema)
     .pipe(RequiresAuditStepSchemaFilter)
     .annotations({ title: 'AuditSteps' }),
-}).annotations({ title: 'AuditAuthoring' });
+}).annotations({ title: 'Audit' });
 
-export type AuditAuthoring = typeof AuditAuthoringSchema.Type;
+export type Audit = typeof AuditSchema.Type;
 
 /**
  * The Puppeteer Replay Userflow Runner Schema parseble and executable by puppeteer replay when decoded.
  */
 export const PuppeteerReplayUserflowRunnerSchema = Schema.Struct({
-  ...AuditAuthoringSchema.fields,
+  ...AuditSchema.fields,
   steps: RunnerStepsSchema.annotations({ title: 'RunnerSteps' }),
 });

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -25,7 +25,7 @@ import {
 } from './puppeteer-replay/puppeteer-replay-step';
 import { DeviceSchema } from './shared/device-type';
 
-const AuthoringPuppeteerReplaySteps = [
+const AuditPuppeteerReplaySteps = [
   ChangeStepSchema,
   ClickStepSchema,
   CloseStepSchema,
@@ -41,26 +41,25 @@ const AuthoringPuppeteerReplaySteps = [
   WaitForExpressionStepSchema,
 ];
 
-export const AuditAuthoringStepSchema = Schema.Union(
-  ...AuthoringPuppeteerReplaySteps,
+export const AuditStepSchema = Schema.Union(
+  ...AuditPuppeteerReplaySteps,
   UserflowStartNavigationStepSchema,
   UserflowEndNavigationStepSchema,
   UserflowStartTimespanStepSchema,
   UserflowEndTimespanStepSchema,
   UserflowSnapshotStepSchema,
 ).annotations({
-  title: 'AuditAuthoringStep',
+  title: 'AuditStep',
 });
 
-const RunnerStepSchema = Schema.Union(...AuthoringPuppeteerReplaySteps, UserflowRunnerStepSchema);
+const RunnerStepSchema = Schema.Union(...AuditPuppeteerReplaySteps, UserflowRunnerStepSchema);
 
-export type AuditStep = typeof AuditAuthoringStepSchema.Type;
-const AuditStepsSchema = Schema.NonEmptyArray(AuditAuthoringStepSchema);
+export type AuditStep = typeof AuditStepSchema.Type;
+const AuditStepsSchema = Schema.NonEmptyArray(AuditStepSchema);
 const RunnerStepsSchema = Schema.NonEmptyArray(RunnerStepSchema);
 
 const RequiresAuditStepSchemaFilter = Schema.filter<typeof AuditStepsSchema>(
-  (steps) =>
-    !!steps.filter((step) => Schema.is(UserflowStepSchema)(step)).length || 'Requires at least one audit steps',
+  (steps) => !!steps.filter((step) => Schema.is(UserflowStepSchema)(step)).length || 'Requires at least one audit step',
 );
 
 const NonNegativeIntFromStringSchema = Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative()).annotations({
@@ -77,7 +76,7 @@ export const AuditSchema = Schema.Struct({
   title: Schema.NonEmptyString,
   device: DeviceSchema,
   timeout: TimeoutSchema,
-  steps: Schema.NonEmptyArray(AuditAuthoringStepSchema)
+  steps: Schema.NonEmptyArray(AuditStepSchema)
     .pipe(RequiresAuditStepSchemaFilter)
     .annotations({ title: 'AuditSteps' }),
 }).annotations({ title: 'Audit' });
@@ -85,7 +84,7 @@ export const AuditSchema = Schema.Struct({
 export type Audit = typeof AuditSchema.Type;
 
 /**
- * The Puppeteer Replay Userflow Runner Schema parseble and executable by puppeteer replay when decoded.
+ * The Puppeteer Replay Userflow Runner Schema parseable and executable by puppeteer replay when decoded.
  */
 export const PuppeteerReplayUserflowRunnerSchema = Schema.Struct({
   ...AuditSchema.fields,

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -1,19 +1,17 @@
 import { Schema } from 'effect';
 import {
-  isUserflowStep,
+  UserflowRunnerStepSchema,
   UserflowEndNavigationStepSchema,
   UserflowEndTimespanStepSchema,
   UserflowSnapshotStepSchema,
   UserflowStartNavigationStepSchema,
   UserflowStartTimespanStepSchema,
-  UserflowAuditStepSchema,
+  UserflowStepSchema,
 } from './lighthouse-userflow/lighthouse-userflow-step';
 import {
   ChangeStepSchema,
   ClickStepSchema,
   CloseStepSchema,
-  CustomStepWithFrameSchema,
-  CustomStepWithTargetSchema,
   DoubleClickStepSchema,
   EmulateNetworkConditionsStepSchema,
   HoverStepSchema,
@@ -27,12 +25,10 @@ import {
 } from './puppeteer-replay/puppeteer-replay-step';
 import { DeviceSchema } from './shared/device-type';
 
-const PuppeteerReplaySteps = [
+const AuthoringPuppeteerReplaySteps = [
   ChangeStepSchema,
   ClickStepSchema,
   CloseStepSchema,
-  CustomStepWithTargetSchema,
-  CustomStepWithFrameSchema,
   DoubleClickStepSchema,
   EmulateNetworkConditionsStepSchema,
   HoverStepSchema,
@@ -45,26 +41,25 @@ const PuppeteerReplaySteps = [
   WaitForExpressionStepSchema,
 ];
 
-export const AuditStepSchema = Schema.Union(
-  ...PuppeteerReplaySteps,
-  // UserFlow
+export const AuditAuthoringStepSchema = Schema.Union(
+  ...AuthoringPuppeteerReplaySteps,
   UserflowStartNavigationStepSchema,
   UserflowEndNavigationStepSchema,
   UserflowStartTimespanStepSchema,
   UserflowEndTimespanStepSchema,
   UserflowSnapshotStepSchema,
 ).annotations({
-  title: 'AuditStep',
+  title: 'AuditAuthoringStep',
 });
 
-const RunnerStepSchema = Schema.Union(UserflowAuditStepSchema, AuditStepSchema);
+const RunnerStepSchema = Schema.Union(...AuthoringPuppeteerReplaySteps, UserflowRunnerStepSchema);
 
-export type AuditStep = typeof AuditStepSchema.Type;
-const AuditStepsSchema = Schema.NonEmptyArray(AuditStepSchema);
+export type AuditStep = typeof AuditAuthoringStepSchema.Type;
+const AuditStepsSchema = Schema.NonEmptyArray(AuditAuthoringStepSchema);
 const RunnerStepsSchema = Schema.NonEmptyArray(RunnerStepSchema);
 
 const RequiresAuditStepSchemaFilter = Schema.filter<typeof AuditStepsSchema>(
-  (steps) => !!steps.filter((step) => isUserflowStep(step)).length || 'Requires at least one audit steps',
+  (steps) => !!steps.filter((step) => Schema.is(UserflowStepSchema)(step)).length || 'Requires at least one audit steps',
 );
 
 const NonNegativeIntFromStringSchema = Schema.NumberFromString.pipe(Schema.int(), Schema.nonNegative()).annotations({
@@ -77,19 +72,21 @@ const TimeoutSchema = Schema.optional(
   }),
 );
 
-export const ReplayUserflowAuditSchema = Schema.Struct({
+export const AuditAuthoringSchema = Schema.Struct({
   title: Schema.NonEmptyString,
   device: DeviceSchema,
   timeout: TimeoutSchema,
-  steps: Schema.NonEmptyArray(AuditStepSchema).pipe(RequiresAuditStepSchemaFilter).annotations({ title: 'AuditSteps' }),
-}).annotations({ title: 'ReplayUserflowAudit' });
+  steps: Schema.NonEmptyArray(AuditAuthoringStepSchema)
+    .pipe(RequiresAuditStepSchemaFilter)
+    .annotations({ title: 'AuditSteps' }),
+}).annotations({ title: 'AuditAuthoring' });
 
-export type ReplayUserflowAudit = typeof ReplayUserflowAuditSchema.Type;
+export type AuditAuthoring = typeof AuditAuthoringSchema.Type;
 
 /**
  * The Puppeteer Replay Userflow Runner Schema parseble and executable by puppeteer replay when decoded.
  */
 export const PuppeteerReplayUserflowRunnerSchema = Schema.Struct({
-  ...ReplayUserflowAuditSchema.fields,
+  ...AuditAuthoringSchema.fields,
   steps: RunnerStepsSchema.annotations({ title: 'RunnerSteps' }),
 });

--- a/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.spec.ts
+++ b/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.spec.ts
@@ -13,7 +13,7 @@ import {
 } from './lighthouse-userflow-step';
 
 describe('UserflowRunnerStepSchema', () => {
-  it.effect('should decode an explicit custom-step authoring schema', () =>
+  it.effect('should decode an explicit custom-step schema', () =>
     Effect.gen(function* () {
       const startNavigationStep = {
         type: 'customStep',
@@ -66,7 +66,7 @@ describe('UserflowRunnerStepSchema', () => {
     }),
   );
 
-  it('rejects replay-shaped custom steps as authoring input', () => {
+  it('rejects replay-shaped custom steps as input', () => {
     expect(
       Schema.is(UserflowStepSchema)({
         type: StepType.CustomStep,
@@ -76,7 +76,7 @@ describe('UserflowRunnerStepSchema', () => {
     ).toBe(false);
   });
 
-  it('validates each explicit authoring schema', () => {
+  it('validates each explicit schema', () => {
     expect(
       Schema.is(UserflowStartNavigationStepSchema)({
         type: 'customStep',
@@ -97,7 +97,7 @@ describe('UserflowRunnerStepSchema', () => {
     ).toBe(true);
   });
 
-  it('exposes replay custom-step output separately from the authoring schemas', () => {
+  it('exposes replay custom-step output separately from the schemas', () => {
     expect(
       Schema.is(ReplayUserflowStepSchema)({
         type: StepType.CustomStep,

--- a/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.spec.ts
+++ b/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.spec.ts
@@ -3,17 +3,25 @@ import { describe, it, expect } from '@effect/vitest';
 import { StepType } from '@puppeteer/replay';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow-step-type';
 
-import { UserflowAuditStepSchema } from './lighthouse-userflow-step';
+import {
+  ReplayUserflowStepSchema,
+  UserflowRunnerStepSchema,
+  UserflowSnapshotStepSchema,
+  UserflowStartNavigationStepSchema,
+  UserflowStartTimespanStepSchema,
+  UserflowStepSchema,
+} from './lighthouse-userflow-step';
 
-describe('UserflowAuditStepSchema', () => {
-  it.effect('should decode UserflowAuditStep', () =>
+describe('UserflowRunnerStepSchema', () => {
+  it.effect('should decode an explicit custom-step authoring schema', () =>
     Effect.gen(function* () {
       const startNavigationStep = {
-        type: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
         name: 'Home Page',
       };
 
-      const decoded = yield* Schema.decodeUnknown(UserflowAuditStepSchema)(startNavigationStep);
+      const decoded = yield* Schema.decodeUnknown(UserflowRunnerStepSchema)(startNavigationStep);
 
       expect(decoded).toEqual({
         type: StepType.CustomStep,
@@ -26,11 +34,12 @@ describe('UserflowAuditStepSchema', () => {
   it.effect('decodes lighthouse steps with flags into replay steps', () =>
     Effect.gen(function* () {
       const input = {
-        type: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
         name: 'Home Page',
       };
 
-      const decoded = yield* Schema.decodeUnknown(UserflowAuditStepSchema)(input);
+      const decoded = yield* Schema.decodeUnknown(UserflowRunnerStepSchema)(input);
 
       expect(decoded).toEqual({
         type: StepType.CustomStep,
@@ -43,10 +52,11 @@ describe('UserflowAuditStepSchema', () => {
   it.effect('decodes lighthouse steps without flags into replay steps', () =>
     Effect.gen(function* () {
       const input = {
-        type: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
       };
 
-      const decoded = yield* Schema.decodeUnknown(UserflowAuditStepSchema)(input);
+      const decoded = yield* Schema.decodeUnknown(UserflowRunnerStepSchema)(input);
 
       expect(decoded).toEqual({
         type: StepType.CustomStep,
@@ -56,17 +66,44 @@ describe('UserflowAuditStepSchema', () => {
     }),
   );
 
-  it.effect('accepts replay custom steps as-is', () =>
-    Effect.gen(function* () {
-      const input = {
+  it('rejects replay-shaped custom steps as authoring input', () => {
+    expect(
+      Schema.is(UserflowStepSchema)({
         type: StepType.CustomStep,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
         parameters: { name: 'Snapshot step' },
-      };
+      }),
+    ).toBe(false);
+  });
 
-      const decoded = yield* Schema.decodeUnknown(UserflowAuditStepSchema)(input);
+  it('validates each explicit authoring schema', () => {
+    expect(
+      Schema.is(UserflowStartNavigationStepSchema)({
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      }),
+    ).toBe(true);
+    expect(
+      Schema.is(UserflowStartTimespanStepSchema)({
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+      }),
+    ).toBe(true);
+    expect(
+      Schema.is(UserflowSnapshotStepSchema)({
+        type: 'customStep',
+        step: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+      }),
+    ).toBe(true);
+  });
 
-      expect(decoded).toEqual(input);
-    }),
-  );
+  it('exposes replay custom-step output separately from the authoring schemas', () => {
+    expect(
+      Schema.is(ReplayUserflowStepSchema)({
+        type: StepType.CustomStep,
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
+        parameters: undefined,
+      }),
+    ).toBe(true);
+  });
 });

--- a/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.ts
+++ b/libs/audit/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.ts
@@ -4,27 +4,33 @@ import {
   PuppeteerReplayStepTypeSchema,
   PUPPETEER_REPLAY_CUSTOM_STEP_TYPE,
 } from '../puppeteer-replay/puppeteer-replay-step-type';
-import { AuditStepTypeSchema } from '../audit-step.schema';
+import { AuditCustomStepTypeSchema, AuditStepTypeSchema } from '../audit-step.schema';
 
 export const UserflowStartNavigationStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION)),
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION)),
   name: Schema.optional(Schema.NonEmptyString),
 });
 export const UserflowEndNavigationStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION)),
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION)),
 });
 
 export const UserflowStartTimespanStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN)),
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN)),
   name: Schema.optional(Schema.NonEmptyString),
 });
 
 export const UserflowEndTimespanStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN)),
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN)),
 });
 
 export const UserflowSnapshotStepSchema = Schema.Struct({
-  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT)),
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AuditCustomStepTypeSchema.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT)),
+  name: Schema.optional(Schema.NonEmptyString),
 });
 
 export const UserflowStepSchema = Schema.Union(
@@ -37,13 +43,7 @@ export const UserflowStepSchema = Schema.Union(
 
 export const isUserflowStep = Schema.is(UserflowStepSchema);
 
-export const UserflowAuditStepTypeScheme = Schema.Literal(
-  LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
-  LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
-  LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
-  LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
-  LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
-) satisfies { readonly literals: readonly string[] };
+export const UserflowAuditStepTypeScheme = AuditCustomStepTypeSchema;
 
 export const UserflowStepTypeWithStepFlagsLiteral = UserflowAuditStepTypeScheme.pipe(
   Schema.pickLiteral(
@@ -57,70 +57,153 @@ export const UserflowStepTypeWithoutStepFlagsLiteral = UserflowAuditStepTypeSche
   Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION, LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN),
 );
 
+const ReplayUserflowStepFlagsSchema = Schema.Struct({
+  name: Schema.optional(Schema.NonEmptyString),
+});
+
 const ReplayUserflowStepWithFlagsSchema = Schema.Struct({
   type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   name: UserflowStepTypeWithStepFlagsLiteral,
-  parameters: Schema.Struct({ name: Schema.NonEmptyString }),
+  parameters: Schema.optional(ReplayUserflowStepFlagsSchema),
 });
 
-export const LighthouseUserflowStepWithFlagsSchema = Schema.Struct({
-  type: UserflowStepTypeWithStepFlagsLiteral,
-  name: Schema.NonEmptyString,
-});
-
-export const LighthouseUserflowStepWithoutFlagsSchema = Schema.Struct({
-  type: UserflowStepTypeWithoutStepFlagsLiteral,
-});
-
-const UserflowStepTypeWithStepFlagsScheme = Schema.transform(
-  LighthouseUserflowStepWithFlagsSchema,
-  ReplayUserflowStepWithFlagsSchema,
+const UserflowStartNavigationRunnerStepSchema = Schema.transform(
+  UserflowStartNavigationStepSchema,
+  Schema.Struct({
+    type: ReplayUserflowStepWithFlagsSchema.fields.type,
+    name: ReplayUserflowStepWithFlagsSchema.fields.name.pipe(
+      Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION),
+    ),
+    parameters: ReplayUserflowStepWithFlagsSchema.fields.parameters,
+  }),
   {
     strict: true,
-    decode: ({ type, name }) => ({
+    decode: ({ name }) => ({
       type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
-      name: type,
-      parameters: { name },
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      parameters: name ? { name } : undefined,
     }),
-    encode: ({ name, parameters }) => ({
-      type: name,
-      name: parameters.name,
+    encode: ({ parameters }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      name: parameters?.name,
     }),
   },
 );
 
-export const ReplayUserflowStepWithoutFlagsSchema = Schema.Struct({
+const UserflowStartTimespanRunnerStepSchema = Schema.transform(
+  UserflowStartTimespanStepSchema,
+  Schema.Struct({
+    type: ReplayUserflowStepWithFlagsSchema.fields.type,
+    name: ReplayUserflowStepWithFlagsSchema.fields.name.pipe(
+      Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN),
+    ),
+    parameters: ReplayUserflowStepWithFlagsSchema.fields.parameters,
+  }),
+  {
+    strict: true,
+    decode: ({ name }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+      parameters: name ? { name } : undefined,
+    }),
+    encode: ({ parameters }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+      name: parameters?.name,
+    }),
+  },
+);
+
+const UserflowSnapshotRunnerStepSchema = Schema.transform(
+  UserflowSnapshotStepSchema,
+  Schema.Struct({
+    type: ReplayUserflowStepWithFlagsSchema.fields.type,
+    name: ReplayUserflowStepWithFlagsSchema.fields.name.pipe(Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT)),
+    parameters: ReplayUserflowStepWithFlagsSchema.fields.parameters,
+  }),
+  {
+    strict: true,
+    decode: ({ name }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+      parameters: name ? { name } : undefined,
+    }),
+    encode: ({ parameters }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+      name: parameters?.name,
+    }),
+  },
+);
+
+const ReplayUserflowStepWithoutFlagsSchema = Schema.Struct({
   type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   name: UserflowStepTypeWithoutStepFlagsLiteral,
   parameters: Schema.optional(Schema.Undefined),
 });
 
-const UserflowStepTypeWithoutStepFlagsScheme = Schema.transform(
-  LighthouseUserflowStepWithoutFlagsSchema,
-  ReplayUserflowStepWithoutFlagsSchema,
+const UserflowEndNavigationRunnerStepSchema = Schema.transform(
+  UserflowEndNavigationStepSchema,
+  Schema.Struct({
+    type: ReplayUserflowStepWithoutFlagsSchema.fields.type,
+    name: ReplayUserflowStepWithoutFlagsSchema.fields.name.pipe(
+      Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION),
+    ),
+    parameters: ReplayUserflowStepWithoutFlagsSchema.fields.parameters,
+  }),
   {
     strict: true,
-    decode: ({ type }) => ({
+    decode: () => ({
       type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
-      name: type,
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
       parameters: undefined,
     }),
-    encode: ({ name }) => ({
-      type: name,
+    encode: () => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+    }),
+  },
+);
+
+const UserflowEndTimespanRunnerStepSchema = Schema.transform(
+  UserflowEndTimespanStepSchema,
+  Schema.Struct({
+    type: ReplayUserflowStepWithoutFlagsSchema.fields.type,
+    name: ReplayUserflowStepWithoutFlagsSchema.fields.name.pipe(
+      Schema.pickLiteral(LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN),
+    ),
+    parameters: ReplayUserflowStepWithoutFlagsSchema.fields.parameters,
+  }),
+  {
+    strict: true,
+    decode: () => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
+      parameters: undefined,
+    }),
+    encode: () => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
     }),
   },
 );
 
 export const ReplayUserflowStepSchema = Schema.Union(
-  ReplayUserflowStepWithoutFlagsSchema,
-  ReplayUserflowStepWithFlagsSchema,
+  Schema.typeSchema(UserflowStartNavigationRunnerStepSchema),
+  Schema.typeSchema(UserflowEndNavigationRunnerStepSchema),
+  Schema.typeSchema(UserflowStartTimespanRunnerStepSchema),
+  Schema.typeSchema(UserflowEndTimespanRunnerStepSchema),
+  Schema.typeSchema(UserflowSnapshotRunnerStepSchema),
 );
 
 export const isReplayUserflowStep = Schema.is(ReplayUserflowStepSchema);
 export const isReplayUserflowStepWithFlags = Schema.is(ReplayUserflowStepWithFlagsSchema);
 
-export const UserflowAuditStepSchema = Schema.Union(
-  UserflowStepTypeWithStepFlagsScheme,
-  UserflowStepTypeWithoutStepFlagsScheme,
-  ReplayUserflowStepSchema,
+export const UserflowRunnerStepSchema = Schema.Union(
+  UserflowStartNavigationRunnerStepSchema,
+  UserflowEndNavigationRunnerStepSchema,
+  UserflowStartTimespanRunnerStepSchema,
+  UserflowEndTimespanRunnerStepSchema,
+  UserflowSnapshotRunnerStepSchema,
 );

--- a/libs/audit/domain/src/lib/runtime/replay.ts
+++ b/libs/audit/domain/src/lib/runtime/replay.ts
@@ -1,29 +1,35 @@
 import type { Step as PuppeteerReplayStep, UserFlow as PuppeteerReplayUserFlow } from '@puppeteer/replay';
+import { PUPPETEER_REPLAY_CUSTOM_STEP_TYPE } from '../puppeteer-replay/puppeteer-replay-step-type';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '../lighthouse-userflow/lighthouse-userflow-step-type';
 
 // @TODO Move to global types and explain what it does
 type Modify<T, R> = Omit<T, keyof R> & R;
 
 interface StartNavigationStep {
-  type: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION;
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION;
   name?: string;
 }
 
 interface EndNavigationStep {
-  type: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION;
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION;
 }
 
 interface StartTimespanStep {
-  type: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN;
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN;
   name?: string;
 }
 
 interface EndTimespanStep {
-  type: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN;
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN;
 }
 
 interface SnapshotStep {
-  type: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT;
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT;
   name?: string;
 }
 

--- a/libs/audit/domain/src/lib/step-type.ts
+++ b/libs/audit/domain/src/lib/step-type.ts
@@ -1,11 +1,11 @@
 import {
+  PUPPETEER_REPLAY_CUSTOM_STEP_TYPE,
   PUPPETEER_REPLAY_ASSERTION_STEP_TYPE,
   PUPPETEER_REPLAY_USER_STEP_TYPE,
 } from './puppeteer-replay/puppeteer-replay-step-type';
-import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
 
 export const STEP_TYPE = {
-  ...LIGHTHOUSE_AUDIT_STEP_TYPE,
+  CUSTOM_STEP: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
   ...PUPPETEER_REPLAY_ASSERTION_STEP_TYPE,
   ...PUPPETEER_REPLAY_USER_STEP_TYPE,
 } as const;

--- a/libs/audit/persistence/src/lib/audit-repo.spec.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.spec.ts
@@ -6,13 +6,13 @@ import path from 'node:path';
 import { auditResultTable, auditRunTable, auditTemplateTable } from './schema';
 
 import { AuditRepo, AuditRepoLive } from './audit-repo';
-import { ReplayUserflowAudit } from '@app-speed/audit/domain';
+import { AuditAuthoring } from '@app-speed/audit/domain';
 import { DbClient } from './db';
 
-const sampleAudit: ReplayUserflowAudit = {
+const sampleAudit: AuditAuthoring = {
   title: 'Sample audit',
   device: 'desktop',
-  steps: [{ type: 'snapshot' }],
+  steps: [{ type: 'customStep', step: 'snapshot' }],
 };
 
 const testDbDir = path.join(process.cwd(), 'tmp');

--- a/libs/audit/persistence/src/lib/audit-repo.spec.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.spec.ts
@@ -6,10 +6,10 @@ import path from 'node:path';
 import { auditResultTable, auditRunTable, auditTemplateTable } from './schema';
 
 import { AuditRepo, AuditRepoLive } from './audit-repo';
-import { AuditAuthoring } from '@app-speed/audit/domain';
+import { Audit } from '@app-speed/audit/domain';
 import { DbClient } from './db';
 
-const sampleAudit: AuditAuthoring = {
+const sampleAudit: Audit = {
   title: 'Sample audit',
   device: 'desktop',
   steps: [{ type: 'customStep', step: 'snapshot' }],

--- a/libs/audit/persistence/src/lib/audit-repo.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer, ParseResult } from 'effect';
 
-import { ReplayUserflowAudit } from '@app-speed/audit/domain';
+import { AuditAuthoring } from '@app-speed/audit/domain';
 
 import { DbClient, QueryError } from './db';
 import { createRun, createTemplate, getTemplateById } from './audit-repo/builder';
@@ -21,7 +21,7 @@ import { getResultByRunId, getRunById } from './audit-repo/viewer';
 export class AuditRepo extends Context.Tag('AuditRepo')<
   AuditRepo,
   {
-    createTemplate: (audit: ReplayUserflowAudit) => Effect.Effect<AuditTemplateId, QueryError>;
+    createTemplate: (audit: AuditAuthoring) => Effect.Effect<AuditTemplateId, QueryError>;
     getTemplateById: (
       id: AuditTemplateId,
     ) => Effect.Effect<AuditTemplateRecord | null, QueryError | ParseResult.ParseError>;
@@ -63,7 +63,7 @@ export const AuditRepoLive = Layer.effect(
     const db = yield* DbClient;
 
     return {
-      createTemplate: (audit: ReplayUserflowAudit) => createTemplate(audit).pipe(Effect.provideService(DbClient, db)),
+      createTemplate: (audit: AuditAuthoring) => createTemplate(audit).pipe(Effect.provideService(DbClient, db)),
       getTemplateById: (id: AuditTemplateId) => getTemplateById(id).pipe(Effect.provideService(DbClient, db)),
       createRun: (templateId: AuditTemplateId) => createRun(templateId).pipe(Effect.provideService(DbClient, db)),
       claimNextRun: () => claimNextRun().pipe(Effect.provideService(DbClient, db)),

--- a/libs/audit/persistence/src/lib/audit-repo.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.ts
@@ -1,6 +1,6 @@
 import { Context, Effect, Layer, ParseResult } from 'effect';
 
-import { AuditAuthoring } from '@app-speed/audit/domain';
+import { Audit } from '@app-speed/audit/domain';
 
 import { DbClient, QueryError } from './db';
 import { createRun, createTemplate, getTemplateById } from './audit-repo/builder';
@@ -21,7 +21,7 @@ import { getResultByRunId, getRunById } from './audit-repo/viewer';
 export class AuditRepo extends Context.Tag('AuditRepo')<
   AuditRepo,
   {
-    createTemplate: (audit: AuditAuthoring) => Effect.Effect<AuditTemplateId, QueryError>;
+    createTemplate: (audit: Audit) => Effect.Effect<AuditTemplateId, QueryError>;
     getTemplateById: (
       id: AuditTemplateId,
     ) => Effect.Effect<AuditTemplateRecord | null, QueryError | ParseResult.ParseError>;
@@ -63,7 +63,7 @@ export const AuditRepoLive = Layer.effect(
     const db = yield* DbClient;
 
     return {
-      createTemplate: (audit: AuditAuthoring) => createTemplate(audit).pipe(Effect.provideService(DbClient, db)),
+      createTemplate: (audit: Audit) => createTemplate(audit).pipe(Effect.provideService(DbClient, db)),
       getTemplateById: (id: AuditTemplateId) => getTemplateById(id).pipe(Effect.provideService(DbClient, db)),
       createRun: (templateId: AuditTemplateId) => createRun(templateId).pipe(Effect.provideService(DbClient, db)),
       claimNextRun: () => claimNextRun().pipe(Effect.provideService(DbClient, db)),

--- a/libs/audit/persistence/src/lib/audit-repo/builder.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/builder.ts
@@ -2,13 +2,13 @@ import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { Clock, Effect } from 'effect';
 
-import { AuditAuthoring } from '@app-speed/audit/domain';
+import { Audit } from '@app-speed/audit/domain';
 
 import { DbClient } from '../db';
 import { auditTemplateTable, auditRunTable } from '../schema';
 import { type AuditTemplateId, type AuditRunId, decodeAuditTemplateRecord } from './shared';
 
-export const createTemplate = Effect.fn('db.auditTemplate.create')(function* (audit: AuditAuthoring) {
+export const createTemplate = Effect.fn('db.auditTemplate.create')(function* (audit: Audit) {
   const db = yield* DbClient;
   const now = new Date(yield* Clock.currentTimeMillis);
   const id = randomUUID() as AuditTemplateId;

--- a/libs/audit/persistence/src/lib/audit-repo/builder.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/builder.ts
@@ -2,13 +2,13 @@ import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
 import { Clock, Effect } from 'effect';
 
-import { ReplayUserflowAudit } from '@app-speed/audit/domain';
+import { AuditAuthoring } from '@app-speed/audit/domain';
 
 import { DbClient } from '../db';
 import { auditTemplateTable, auditRunTable } from '../schema';
 import { type AuditTemplateId, type AuditRunId, decodeAuditTemplateRecord } from './shared';
 
-export const createTemplate = Effect.fn('db.auditTemplate.create')(function* (audit: ReplayUserflowAudit) {
+export const createTemplate = Effect.fn('db.auditTemplate.create')(function* (audit: AuditAuthoring) {
   const db = yield* DbClient;
   const now = new Date(yield* Clock.currentTimeMillis);
   const id = randomUUID() as AuditTemplateId;

--- a/libs/audit/persistence/src/lib/audit-repo/shared.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/shared.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect';
 
-import { ReplayUserflowAuditSchema } from '@app-speed/audit/domain';
+import { AuditAuthoringSchema } from '@app-speed/audit/domain';
 
 export const AuditTemplateIdSchema = Schema.NonEmptyString.pipe(Schema.brand('AuditTemplateId'));
 export type AuditTemplateId = typeof AuditTemplateIdSchema.Type;
@@ -13,7 +13,7 @@ export type AuditStatus = typeof AuditStatusSchema.Type;
 
 const AuditTemplateRecordSchema = Schema.Struct({
   id: AuditTemplateIdSchema,
-  data: ReplayUserflowAuditSchema,
+  data: AuditAuthoringSchema,
   createAt: Schema.DateFromSelf,
   updatedAt: Schema.DateFromSelf,
 });
@@ -22,7 +22,7 @@ export type AuditTemplateRecord = typeof AuditTemplateRecordSchema.Type;
 const AuditRunRecordSchema = Schema.Struct({
   id: AuditRunIdSchema,
   templateId: AuditTemplateIdSchema,
-  data: ReplayUserflowAuditSchema,
+  data: AuditAuthoringSchema,
   status: AuditStatusSchema,
   createdAt: Schema.DateFromSelf,
   updatedAt: Schema.DateFromSelf,

--- a/libs/audit/persistence/src/lib/audit-repo/shared.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/shared.ts
@@ -1,6 +1,6 @@
 import { Schema } from 'effect';
 
-import { AuditAuthoringSchema } from '@app-speed/audit/domain';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 export const AuditTemplateIdSchema = Schema.NonEmptyString.pipe(Schema.brand('AuditTemplateId'));
 export type AuditTemplateId = typeof AuditTemplateIdSchema.Type;
@@ -13,7 +13,7 @@ export type AuditStatus = typeof AuditStatusSchema.Type;
 
 const AuditTemplateRecordSchema = Schema.Struct({
   id: AuditTemplateIdSchema,
-  data: AuditAuthoringSchema,
+  data: AuditSchema,
   createAt: Schema.DateFromSelf,
   updatedAt: Schema.DateFromSelf,
 });
@@ -22,7 +22,7 @@ export type AuditTemplateRecord = typeof AuditTemplateRecordSchema.Type;
 const AuditRunRecordSchema = Schema.Struct({
   id: AuditRunIdSchema,
   templateId: AuditTemplateIdSchema,
-  data: AuditAuthoringSchema,
+  data: AuditSchema,
   status: AuditStatusSchema,
   createdAt: Schema.DateFromSelf,
   updatedAt: Schema.DateFromSelf,

--- a/libs/audit/persistence/src/lib/schema.ts
+++ b/libs/audit/persistence/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
-import { type AuditAuthoring } from '@app-speed/audit/domain';
+import { type Audit } from '@app-speed/audit/domain';
 
 export const auditStatusValues = ['SCHEDULED', 'IN_PROGRESS', 'COMPLETE'] as const;
 export type AuditStatus = (typeof auditStatusValues)[number];
@@ -12,7 +12,7 @@ export const auditTemplateTable = sqliteTable(
   'AuditTemplate',
   {
     id: text('id').primaryKey().$defaultFn(randomUUID),
-    data: text('data', { mode: 'json' }).$type<AuditAuthoring>().notNull(),
+    data: text('data', { mode: 'json' }).$type<Audit>().notNull(),
     createdAt: integer('createdAt', { mode: 'timestamp_ms' })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/libs/audit/persistence/src/lib/schema.ts
+++ b/libs/audit/persistence/src/lib/schema.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { integer, sqliteTable, text, uniqueIndex } from 'drizzle-orm/sqlite-core';
-import { type ReplayUserflowAudit } from '@app-speed/audit/domain';
+import { type AuditAuthoring } from '@app-speed/audit/domain';
 
 export const auditStatusValues = ['SCHEDULED', 'IN_PROGRESS', 'COMPLETE'] as const;
 export type AuditStatus = (typeof auditStatusValues)[number];
@@ -12,7 +12,7 @@ export const auditTemplateTable = sqliteTable(
   'AuditTemplate',
   {
     id: text('id').primaryKey().$defaultFn(randomUUID),
-    data: text('data', { mode: 'json' }).$type<ReplayUserflowAudit>().notNull(),
+    data: text('data', { mode: 'json' }).$type<AuditAuthoring>().notNull(),
     createdAt: integer('createdAt', { mode: 'timestamp_ms' })
       .notNull()
       .$defaultFn(() => new Date()),

--- a/libs/audit/portal/builder/src/lib/audit-details.ts
+++ b/libs/audit/portal/builder/src/lib/audit-details.ts
@@ -1,6 +1,6 @@
-import { AuditAuthoring } from '@app-speed/audit/domain';
+import { Audit } from '@app-speed/audit/domain';
 
-export type AuditDetails = AuditAuthoring;
+export type AuditDetails = Audit;
 
 export const DEFAULT_AUDIT_DETAILS = {
   title: '',

--- a/libs/audit/portal/builder/src/lib/audit-details.ts
+++ b/libs/audit/portal/builder/src/lib/audit-details.ts
@@ -1,20 +1,14 @@
-import { DeviceType } from '@app-speed/audit/domain';
-import { Step } from './step-details';
+import { AuditAuthoring } from '@app-speed/audit/domain';
 
-export interface AuditDetails {
-  title: string;
-  device: DeviceType;
-  timeout: number;
-  steps: Step[]; // TODO fix type
-}
+export type AuditDetails = AuditAuthoring;
 
 export const DEFAULT_AUDIT_DETAILS = {
   title: '',
   device: 'mobile',
   timeout: 30000,
   steps: [
-    { type: 'startNavigation', stepOptions: { name: 'Initial Navigation' } },
+    { type: 'customStep', step: 'startNavigation', name: 'Initial Navigation' },
     { type: 'navigate', url: '' },
-    { type: 'endNavigation' },
+    { type: 'customStep', step: 'endNavigation' },
   ],
-} as const as any as AuditDetails;
+} as const satisfies AuditDetails;

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '@app-speed/audit/domain';
+import { StepFormGroup } from './audit-builder-form';
+
+describe('StepFormGroup', () => {
+  it('derives the unified selector value from custom-step authoring objects', () => {
+    const formGroup = new StepFormGroup({
+      type: 'customStep',
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      name: 'Initial Navigation',
+    });
+
+    expect(formGroup.selectionControl.value).toBe(LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION);
+    expect(formGroup.getRawValue()).toEqual({
+      type: 'customStep',
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+      name: 'Initial Navigation',
+    });
+  });
+
+  it('selecting a custom step produces the explicit authoring object shape', () => {
+    const formGroup = new StepFormGroup({ type: '' });
+
+    formGroup.resetStepControls(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT);
+
+    expect(formGroup.selectionControl.value).toBe(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT);
+    expect(formGroup.getRawValue()).toMatchObject({
+      type: 'customStep',
+      step: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+    });
+    expect(formGroup.fields()).toEqual(['name']);
+  });
+});

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -3,7 +3,7 @@ import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '@app-speed/audit/domain';
 import { StepFormGroup } from './audit-builder-form';
 
 describe('StepFormGroup', () => {
-  it('derives the unified selector value from custom-step authoring objects', () => {
+  it('derives the unified selector value from custom-step objects', () => {
     const formGroup = new StepFormGroup({
       type: 'customStep',
       step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
@@ -18,7 +18,7 @@ describe('StepFormGroup', () => {
     });
   });
 
-  it('selecting a custom step produces the explicit authoring object shape', () => {
+  it('selecting a custom step produces the explicit object shape', () => {
     const formGroup = new StepFormGroup({ type: '' });
 
     formGroup.resetStepControls(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT);

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.ts
@@ -1,10 +1,10 @@
 import { signal } from '@angular/core';
 import { AbstractControl, FormArray, FormControl, FormGroup, Validators } from '@angular/forms';
-import { AuditStep, DEVICE_OPTIONS, DeviceType } from '@app-speed/audit/domain';
+import { AuditStep, DeviceType, STEP_TYPE } from '@app-speed/audit/domain';
 import { AuditDetails } from '../audit-details';
 import { InputType } from '../input-type';
 import { PropertyName } from '../property-name';
-import { STEP_OPTIONS, StepDetails, Step } from '../step-details';
+import { EMPTY_STEP, findStepDetails, Step, StepDetails, StepSelection, stepSelectionFromStep } from '../step-details';
 import { StepProperty } from '../step-property.model';
 
 import { stepPropertyFactoryMap } from './step-property';
@@ -28,11 +28,11 @@ export class AuditFormGroup extends FormGroup<{
         validators: [Validators.required],
         nonNullable: true,
       }),
-      device: new FormControl<DeviceType>(DEVICE_OPTIONS[0], {
+      device: new FormControl<DeviceType>(audit.device, {
         validators: [Validators.required],
         nonNullable: true,
       }),
-      timeout: new FormControl<number>(30000, {
+      timeout: new FormControl<number>(audit.timeout ?? 30000, {
         validators: [Validators.required],
         nonNullable: true,
       }),
@@ -50,12 +50,14 @@ export class AuditFormGroup extends FormGroup<{
     this.controls.steps.removeAt(index);
   }
 }
-
 export class StepFormGroup extends FormGroup {
-  readonly fields = signal<PropertyName[]>(['type']);
+  readonly fields = signal<PropertyName[]>([]);
   readonly optionalFields = signal<PropertyName[]>([]);
-
-  stepSchema!: StepDetails;
+  readonly selectionControl = new FormControl<StepSelection | ''>('', {
+    validators: [Validators.required],
+    nonNullable: true,
+  });
+  stepSchema: StepDetails = EMPTY_STEP;
 
   stepProperty<TInputType extends InputType = InputType>(propertyName: PropertyName): StepProperty<TInputType> {
     const stepProperty = this.stepSchema.properties.find((prop) => prop.name === propertyName);
@@ -106,9 +108,9 @@ export class StepFormGroup extends FormGroup {
   }
 
   constructor(step: Step | AuditStep) {
-    const typeControl = stepPropertyFactoryMap.type(step);
-    super({ type: typeControl });
-    this.setupControls(step.type, step);
+    super({});
+    this.selectionControl.setValue(stepSelectionFromStep(step));
+    this.setupControls(this.selectionControl.value, step);
   }
 
   addOptionalField(field: PropertyName): void {
@@ -124,30 +126,43 @@ export class StepFormGroup extends FormGroup {
     this.removeControl(field);
   }
 
-  private setupControls(stepType: string, step?: Step | AuditStep): void {
-    const stepSchema = STEP_OPTIONS.find(({ type }) => type === stepType)!;
+  private setupControls(stepSelection: StepSelection | '', step?: Step | AuditStep): void {
+    const stepSchema = findStepDetails(stepSelection);
     this.stepSchema = stepSchema;
+    this.addControl('type', stepPropertyFactoryMap.type(stepSchema.step));
+
+    if (stepSchema.step.type === STEP_TYPE.CUSTOM_STEP) {
+      this.addControl(
+        'step',
+        new FormControl(stepSchema.step.step, {
+          validators: [Validators.required],
+          nonNullable: true,
+        }),
+      );
+    }
 
     const stepProperties = stepSchema.properties
-      .filter((prop) => prop.name !== 'type')
       .filter((prop) => prop.required || (step && prop.name in step));
     stepProperties.forEach((stepProperty) =>
       this.addControl(stepProperty.name, stepPropertyFactoryMap[stepProperty.name](step)),
     );
 
-    const stepActiveFields: PropertyName[] = ['type', ...stepProperties.map(({ name }) => name)];
+    const stepActiveFields = stepProperties.map(({ name }) => name);
     this.fields.set(stepActiveFields);
     this.optionalFields.set(
       stepSchema.properties.filter(({ name }) => !stepActiveFields.includes(name)).map(({ name }) => name),
     );
   }
 
-  resetStepControls(stepType: string): void {
-    Object.keys(this.controls)
-      .filter((key) => key !== 'type')
-      .forEach((key) => {
-        this.removeControl(key);
-      });
-    this.setupControls(stepType);
+  resetStepControls(stepSelection: StepSelection | ''): void {
+    if (this.selectionControl.value !== stepSelection) {
+      this.selectionControl.setValue(stepSelection, { emitEvent: false });
+    }
+
+    Object.keys(this.controls).forEach((key) => {
+      this.removeControl(key);
+    });
+
+    this.setupControls(stepSelection);
   }
 }

--- a/libs/audit/portal/builder/src/lib/components/audit-step.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-step.component.ts
@@ -1,13 +1,18 @@
 import { afterNextRender, ChangeDetectionStrategy, Component, DestroyRef, inject, input } from '@angular/core';
+import { ReactiveFormsModule } from '@angular/forms';
 import { MatExpansionPanel, MatExpansionPanelHeader, MatExpansionPanelTitle } from '@angular/material/expansion';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '@app-speed/audit/domain';
 import { StepFormGroup } from './audit-builder-form';
 import { MatFabButton, MatIconButton } from '@angular/material/button';
+import { MatOption, MatOptgroup } from '@angular/material/core';
+import { MatFormField, MatLabel } from '@angular/material/form-field';
 import { distinctUntilChanged, skip, startWith, tap } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ArrayField, InputField, OptionsField } from '@app-speed/audit/portal/ui/form-fields';
 import { MatIcon } from '@angular/material/icon';
+import { MatSelect } from '@angular/material/select';
 import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
+import { STEP_SELECTION_OPTIONS_GROUPED } from '../step-property.model';
 
 @Component({
   selector: 'ui-audit-builder-step',
@@ -16,7 +21,7 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
       @let control = stepControl();
       <mat-expansion-panel-header>
         <mat-panel-title>
-          @if (control.controls['type'].value; as stepType) {
+          @if (control.selectionControl.value; as stepType) {
             <span class="step-title">
               <mat-icon
                 [svgIcon]="isLighthouseStep(stepType) ? 'lighthouse-badge' : 'puppeteer-badge'"
@@ -32,6 +37,23 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
       </mat-expansion-panel-header>
       <ng-content />
       <ng-container>
+        <mat-form-field>
+          <mat-label>Type</mat-label>
+          <mat-select [formControl]="control.selectionControl">
+            <mat-option value=""></mat-option>
+            @for (optionGroup of stepTypeOptions; track optionGroup.label) {
+              <mat-optgroup>
+                <span class="option-group-label">
+                  <mat-icon [svgIcon]="optionGroup.icon" aria-hidden="true" />
+                  <span>{{ optionGroup.label }}</span>
+                </span>
+                @for (option of optionGroup.options; track option) {
+                  <mat-option [value]="option">{{ option }}</mat-option>
+                }
+              </mat-optgroup>
+            }
+          </mat-select>
+        </mat-form-field>
         @for (stepField of control.fields(); track stepField) {
           @let fieldType = control.stepProperty(stepField).inputType;
           @switch (fieldType) {
@@ -150,8 +172,14 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
     MatExpansionPanel,
     MatExpansionPanelHeader,
     MatExpansionPanelTitle,
+    ReactiveFormsModule,
     MatFabButton,
     MatIconButton,
+    MatFormField,
+    MatLabel,
+    MatSelect,
+    MatOption,
+    MatOptgroup,
     OptionsField,
     ToTitleCasePipe,
     InputField,
@@ -181,6 +209,12 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
       gap: 16px;
       flex-wrap: wrap;
     }
+
+    .option-group-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -188,6 +222,7 @@ export class AuditStepComponent {
   stepControl = input.required<StepFormGroup>();
   private readonly destroyRef = inject(DestroyRef);
   private readonly lighthouseStepTypes = new Set<string>(Object.values(LIGHTHOUSE_AUDIT_STEP_TYPE));
+  protected readonly stepTypeOptions = STEP_SELECTION_OPTIONS_GROUPED;
 
   constructor() {
     afterNextRender(() => this.handleStepTypeChange());
@@ -198,10 +233,10 @@ export class AuditStepComponent {
   }
 
   private handleStepTypeChange(): void {
-    const stepTypeControl = this.stepControl().controls['type'];
-    stepTypeControl.valueChanges
+    const stepSelectionControl = this.stepControl().selectionControl;
+    stepSelectionControl.valueChanges
       .pipe(
-        startWith(stepTypeControl.value),
+        startWith(stepSelectionControl.value),
         distinctUntilChanged(),
         skip(1),
         tap((newStepType) => this.stepControl().resetStepControls(newStepType)),

--- a/libs/audit/portal/builder/src/lib/components/audit-step.stories.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-step.stories.ts
@@ -1,9 +1,9 @@
 import { applicationConfig, type Meta, type StoryObj } from '@storybook/angular';
 import { provideAuditBuilderIcons } from '@app-speed/audit/portal/ui/icons';
-import { STEP_TYPE } from '@app-speed/audit/domain';
+import { LIGHTHOUSE_AUDIT_STEP_TYPE, STEP_TYPE } from '@app-speed/audit/domain';
 import { StepFormGroup } from './audit-builder-form';
 import { AuditStepComponent } from './audit-step.component';
-import type { StepDetails } from '../step-details';
+import type { Step } from '../step-details';
 
 const meta: Meta<AuditStepComponent> = {
   title: 'Patterns/Audit Builder/Step',
@@ -17,28 +17,56 @@ const meta: Meta<AuditStepComponent> = {
 export default meta;
 type Story = StoryObj<AuditStepComponent>;
 
-const createStory = (type: StepDetails['type']): Story => ({
+const createStory = (step: Step): Story => ({
   render: () => {
-    return { props: { stepControl: new StepFormGroup({ type }) } };
+    return { props: { stepControl: new StepFormGroup(step) } };
   },
 });
 
-export const Empty = createStory('');
-export const StartNavigation = createStory(STEP_TYPE.START_NAVIGATION);
-export const EndNavigation = createStory(STEP_TYPE.END_NAVIGATION);
-export const StartTimespan = createStory(STEP_TYPE.START_TIMESPAN);
-export const EndTimespan = createStory(STEP_TYPE.END_TIMESPAN);
-export const Snapshot = createStory(STEP_TYPE.SNAPSHOT);
-export const WaitForElement = createStory(STEP_TYPE.WAIT_FOR_ELEMENT);
-export const WaitForExpression = createStory(STEP_TYPE.WAIT_FOR_EXPRESSION);
-export const Change = createStory(STEP_TYPE.CHANGE);
-export const Click = createStory(STEP_TYPE.CLICK);
-export const Close = createStory(STEP_TYPE.CLOSE);
-export const DoubleClick = createStory(STEP_TYPE.DOUBLE_CLICK);
-export const EmulateNetworkConditions = createStory(STEP_TYPE.EMULATE_NETWORK_CONDITIONS);
-export const Hover = createStory(STEP_TYPE.HOVER);
-export const KeyDown = createStory(STEP_TYPE.KEY_DOWN);
-export const KeyUp = createStory(STEP_TYPE.KEY_UP);
-export const Navigate = createStory(STEP_TYPE.NAVIGATE);
-export const Scroll = createStory(STEP_TYPE.SCROLL);
-export const SetViewport = createStory(STEP_TYPE.SET_VIEWPORT);
+export const Empty = createStory({ type: '' });
+export const StartNavigation = createStory({
+  type: STEP_TYPE.CUSTOM_STEP,
+  step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+});
+export const EndNavigation = createStory({
+  type: STEP_TYPE.CUSTOM_STEP,
+  step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+});
+export const StartTimespan = createStory({
+  type: STEP_TYPE.CUSTOM_STEP,
+  step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+});
+export const EndTimespan = createStory({
+  type: STEP_TYPE.CUSTOM_STEP,
+  step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
+});
+export const Snapshot = createStory({
+  type: STEP_TYPE.CUSTOM_STEP,
+  step: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+});
+export const WaitForElement = createStory({ type: STEP_TYPE.WAIT_FOR_ELEMENT, count: 1, selectors: [''] });
+export const WaitForExpression = createStory({ type: STEP_TYPE.WAIT_FOR_EXPRESSION, expression: '' });
+export const Change = createStory({ type: STEP_TYPE.CHANGE, selectors: [''], value: '' });
+export const Click = createStory({ type: STEP_TYPE.CLICK, offsetX: 1, offsetY: 1, selectors: [''] });
+export const Close = createStory({ type: STEP_TYPE.CLOSE });
+export const DoubleClick = createStory({ type: STEP_TYPE.DOUBLE_CLICK, offsetX: 1, offsetY: 1, selectors: [''] });
+export const EmulateNetworkConditions = createStory({
+  type: STEP_TYPE.EMULATE_NETWORK_CONDITIONS,
+  download: 1,
+  latency: 1,
+  upload: 1,
+});
+export const Hover = createStory({ type: STEP_TYPE.HOVER, selectors: [''] });
+export const KeyDown = createStory({ type: STEP_TYPE.KEY_DOWN, key: '' });
+export const KeyUp = createStory({ type: STEP_TYPE.KEY_UP, key: '' });
+export const Navigate = createStory({ type: STEP_TYPE.NAVIGATE, url: '' });
+export const Scroll = createStory({ type: STEP_TYPE.SCROLL, x: 1, y: 1 });
+export const SetViewport = createStory({
+  type: STEP_TYPE.SET_VIEWPORT,
+  deviceScaleFactor: 1,
+  hasTouch: false,
+  height: 1,
+  isLandscape: false,
+  isMobile: false,
+  width: 1,
+});

--- a/libs/audit/portal/builder/src/lib/components/audit-step.stories.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-step.stories.ts
@@ -57,10 +57,10 @@ export const EmulateNetworkConditions = createStory({
   upload: 1,
 });
 export const Hover = createStory({ type: STEP_TYPE.HOVER, selectors: [''] });
-export const KeyDown = createStory({ type: STEP_TYPE.KEY_DOWN, key: '' });
-export const KeyUp = createStory({ type: STEP_TYPE.KEY_UP, key: '' });
+export const KeyDown = createStory({ type: STEP_TYPE.KEY_DOWN, key: 'Enter' });
+export const KeyUp = createStory({ type: STEP_TYPE.KEY_UP, key: 'Enter' });
 export const Navigate = createStory({ type: STEP_TYPE.NAVIGATE, url: '' });
-export const Scroll = createStory({ type: STEP_TYPE.SCROLL, x: 1, y: 1 });
+export const Scroll = createStory({ type: STEP_TYPE.SCROLL, selectors: [''], x: 1, y: 1 });
 export const SetViewport = createStory({
   type: STEP_TYPE.SET_VIEWPORT,
   deviceScaleFactor: 1,

--- a/libs/audit/portal/builder/src/lib/feature/builder-error-message.spec.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder-error-message.spec.ts
@@ -11,7 +11,7 @@ describe('getAuditRequestErrorMessage', () => {
       url: '/api/audit/schedule',
       error: {
         _tag: 'HttpApiDecodeError',
-        message: 'AuditAuthoring\n└─ ["title"]\n   └─ is missing',
+        message: 'Audit\n└─ ["title"]\n   └─ is missing',
         issues: [
           {
             _tag: 'Missing',

--- a/libs/audit/portal/builder/src/lib/feature/builder-error-message.spec.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder-error-message.spec.ts
@@ -11,7 +11,7 @@ describe('getAuditRequestErrorMessage', () => {
       url: '/api/audit/schedule',
       error: {
         _tag: 'HttpApiDecodeError',
-        message: 'ReplayUserflowAudit\n└─ ["title"]\n   └─ is missing',
+        message: 'AuditAuthoring\n└─ ["title"]\n   └─ is missing',
         issues: [
           {
             _tag: 'Missing',

--- a/libs/audit/portal/builder/src/lib/step-details.ts
+++ b/libs/audit/portal/builder/src/lib/step-details.ts
@@ -1,30 +1,32 @@
-// TODO Implement record control inputs types, this is an array of key value pairs.
-// TODO Implement boolean control input type.
-// TODO implement stringArray
-
+import { AuditStep, LIGHTHOUSE_AUDIT_STEP_TYPE, STEP_TYPE, StepType } from '@app-speed/audit/domain';
 import { requiredFeature, STEP_PROPERTY, StepProperty } from './step-property.model';
-import { STEP_TYPE, StepType } from '@app-speed/audit/domain';
-import { PROPERTY_NAME, PropertyName } from './property-name';
-import { InputType } from './input-type';
 
-export type StepDetails = {
-  type: StepType | '';
+type CustomStepSelection = (typeof LIGHTHOUSE_AUDIT_STEP_TYPE)[keyof typeof LIGHTHOUSE_AUDIT_STEP_TYPE];
+type ReplayStepSelection = Exclude<StepType, typeof STEP_TYPE.CUSTOM_STEP>;
+
+export type StepSelection = ReplayStepSelection | CustomStepSelection;
+export type Step = AuditStep | { type: '' };
+
+export type StepDetails<TStep extends Step = Step> = {
+  selection: StepSelection | '';
+  step: TStep;
   properties: StepProperty[];
   description?: string;
 };
 
-export const EMPTY_STEP: StepDetails = {
-  type: '',
-  properties: [STEP_PROPERTY.type],
+export const EMPTY_STEP: StepDetails<{ type: '' }> = {
+  selection: '',
+  step: { type: '' },
+  properties: [],
 };
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.WaitForElementStep.md
 const WAIT_FOR_ELEMENT_STEP: StepDetails = {
-  type: STEP_TYPE.WAIT_FOR_ELEMENT,
+  selection: STEP_TYPE.WAIT_FOR_ELEMENT,
+  step: { type: STEP_TYPE.WAIT_FOR_ELEMENT, count: 1, selectors: [] },
   description:
     'waitForElement allows waiting for the presence (or absence) of the number of elements identified by the selector.',
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.attributes,
     STEP_PROPERTY.count,
@@ -40,10 +42,10 @@ const WAIT_FOR_ELEMENT_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.WaitForExpressionStep.md
 const WAIT_FOR_EXPRESSION_STEP: StepDetails = {
-  type: STEP_TYPE.WAIT_FOR_EXPRESSION,
+  selection: STEP_TYPE.WAIT_FOR_EXPRESSION,
+  step: { type: STEP_TYPE.WAIT_FOR_EXPRESSION, expression: '' },
   description: 'waitForExpression allows for a JavaScript expression to resolve to truthy value.',
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     requiredFeature(STEP_PROPERTY.expression),
     STEP_PROPERTY.frame,
@@ -54,9 +56,9 @@ const WAIT_FOR_EXPRESSION_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.ChangeStep.md
 const CHANGE_STEP: StepDetails = {
-  type: STEP_TYPE.CHANGE,
+  selection: STEP_TYPE.CHANGE,
+  step: { type: STEP_TYPE.CHANGE, selectors: [], value: '' },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.frame,
     requiredFeature(STEP_PROPERTY.selectors),
@@ -66,9 +68,9 @@ const CHANGE_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.ClickStep.md
 const CLICK_STEP: StepDetails = {
-  type: STEP_TYPE.CLICK,
+  selection: STEP_TYPE.CLICK,
+  step: { type: STEP_TYPE.CLICK, offsetX: 1, offsetY: 1, selectors: [] },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.button,
     STEP_PROPERTY.deviceType,
@@ -84,8 +86,9 @@ const CLICK_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.CloseStep.md
 const CLOSE_STEP: StepDetails = {
-  type: STEP_TYPE.CLOSE,
-  properties: [STEP_PROPERTY.type, STEP_PROPERTY.assertEvents, STEP_PROPERTY.target, STEP_PROPERTY.timeout],
+  selection: STEP_TYPE.CLOSE,
+  step: { type: STEP_TYPE.CLOSE },
+  properties: [STEP_PROPERTY.assertEvents, STEP_PROPERTY.target, STEP_PROPERTY.timeout],
 };
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.CustomStepParams.md
@@ -93,9 +96,9 @@ const CLOSE_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.DoubleClickStep.md
 const DOUBLE_CLICK_STEP: StepDetails = {
-  type: STEP_TYPE.DOUBLE_CLICK,
+  selection: STEP_TYPE.DOUBLE_CLICK,
+  step: { type: STEP_TYPE.DOUBLE_CLICK, offsetX: 1, offsetY: 1, selectors: [] },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.button,
     STEP_PROPERTY.deviceType,
@@ -111,9 +114,9 @@ const DOUBLE_CLICK_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.EmulateNetworkConditionsStep.md
 const EMULATE_NETWORK_CONDITIONS_STEP: StepDetails = {
-  type: STEP_TYPE.EMULATE_NETWORK_CONDITIONS,
+  selection: STEP_TYPE.EMULATE_NETWORK_CONDITIONS,
+  step: { type: STEP_TYPE.EMULATE_NETWORK_CONDITIONS, download: 1, latency: 1, upload: 1 },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     requiredFeature(STEP_PROPERTY.download),
     requiredFeature(STEP_PROPERTY.latency),
@@ -125,9 +128,9 @@ const EMULATE_NETWORK_CONDITIONS_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.HoverStep.md
 const HOVER_STEP: StepDetails = {
-  type: STEP_TYPE.HOVER,
+  selection: STEP_TYPE.HOVER,
+  step: { type: STEP_TYPE.HOVER, selectors: [] },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.frame,
     requiredFeature(STEP_PROPERTY.selectors),
@@ -138,9 +141,9 @@ const HOVER_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.KeyDownStep.md
 const KEY_DOWN_STEP: StepDetails = {
-  type: STEP_TYPE.KEY_DOWN,
+  selection: STEP_TYPE.KEY_DOWN,
+  step: { type: STEP_TYPE.KEY_DOWN, key: 'Enter' },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     requiredFeature(STEP_PROPERTY.key),
     STEP_PROPERTY.target,
@@ -150,9 +153,9 @@ const KEY_DOWN_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.KeyUpStep.md
 const KEY_UP_STEP: StepDetails = {
-  type: STEP_TYPE.KEY_UP,
+  selection: STEP_TYPE.KEY_UP,
+  step: { type: STEP_TYPE.KEY_UP, key: 'Enter' },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     requiredFeature(STEP_PROPERTY.key),
     STEP_PROPERTY.target,
@@ -162,9 +165,9 @@ const KEY_UP_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.NavigateStep.md
 const NAVIGATE_STEP: StepDetails = {
-  type: STEP_TYPE.NAVIGATE,
+  selection: STEP_TYPE.NAVIGATE,
+  step: { type: STEP_TYPE.NAVIGATE, url: '' },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.target,
     STEP_PROPERTY.timeout,
@@ -174,11 +177,12 @@ const NAVIGATE_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.ScrollPageStep.md
 const SCROLL_PAGE_STEP: StepDetails = {
-  type: STEP_TYPE.SCROLL,
+  selection: STEP_TYPE.SCROLL,
+  step: { type: STEP_TYPE.SCROLL, selectors: [], x: 1, y: 1 },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     STEP_PROPERTY.frame,
+    requiredFeature(STEP_PROPERTY.selectors),
     STEP_PROPERTY.target,
     STEP_PROPERTY.timeout,
     STEP_PROPERTY.x,
@@ -188,9 +192,17 @@ const SCROLL_PAGE_STEP: StepDetails = {
 
 // DOCS https://github.com/puppeteer/replay/blob/main/docs/api/interfaces/Schema.SetViewportStep.md
 const SET_VIEWPORT_STEP: StepDetails = {
-  type: STEP_TYPE.SET_VIEWPORT,
+  selection: STEP_TYPE.SET_VIEWPORT,
+  step: {
+    type: STEP_TYPE.SET_VIEWPORT,
+    deviceScaleFactor: 1,
+    hasTouch: false,
+    height: 1,
+    isLandscape: false,
+    isMobile: false,
+    width: 1,
+  },
   properties: [
-    STEP_PROPERTY.type,
     STEP_PROPERTY.assertEvents,
     requiredFeature(STEP_PROPERTY.deviceScaleFactor),
     requiredFeature(STEP_PROPERTY.hasTouch),
@@ -204,28 +216,33 @@ const SET_VIEWPORT_STEP: StepDetails = {
 };
 
 const START_NAVIGATION: StepDetails = {
-  type: STEP_TYPE.START_NAVIGATION,
-  properties: [STEP_PROPERTY.type, requiredFeature(STEP_PROPERTY.name)],
+  selection: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+  step: { type: STEP_TYPE.CUSTOM_STEP, step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION },
+  properties: [requiredFeature(STEP_PROPERTY.name)],
 };
 
 const END_NAVIGATION: StepDetails = {
-  type: STEP_TYPE.END_NAVIGATION,
-  properties: [STEP_PROPERTY.type],
+  selection: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+  step: { type: STEP_TYPE.CUSTOM_STEP, step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION },
+  properties: [],
 };
 
 const START_TIMESPAN: StepDetails = {
-  type: STEP_TYPE.START_TIMESPAN,
-  properties: [STEP_PROPERTY.type, requiredFeature(STEP_PROPERTY.name)],
+  selection: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+  step: { type: STEP_TYPE.CUSTOM_STEP, step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN },
+  properties: [requiredFeature(STEP_PROPERTY.name)],
 };
 
 const END_TIMESPAN: StepDetails = {
-  type: STEP_TYPE.END_TIMESPAN,
-  properties: [STEP_PROPERTY.type],
+  selection: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
+  step: { type: STEP_TYPE.CUSTOM_STEP, step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN },
+  properties: [],
 };
 
 const SNAPSHOT: StepDetails = {
-  type: STEP_TYPE.SNAPSHOT,
-  properties: [STEP_PROPERTY.type, requiredFeature(STEP_PROPERTY.name)],
+  selection: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+  step: { type: STEP_TYPE.CUSTOM_STEP, step: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT },
+  properties: [requiredFeature(STEP_PROPERTY.name)],
 };
 
 const AUDIT_STEPS: StepDetails[] = [START_NAVIGATION, END_NAVIGATION, START_TIMESPAN, END_TIMESPAN, SNAPSHOT];
@@ -248,7 +265,8 @@ const USER_STEPS: StepDetails[] = [
 
 export const STEP_OPTIONS = [EMPTY_STEP, ASSERTION_STEPS, USER_STEPS, AUDIT_STEPS].flat();
 
-// @TODO improve this type
-export type Step = { [PROPERTY_NAME.TYPE]: StepDetails['type'] } & Partial<
-  Record<Exclude<PropertyName, typeof PROPERTY_NAME.TYPE>, InputType>
->;
+export const stepSelectionFromStep = (step: Step): StepSelection | '' =>
+  step.type === STEP_TYPE.CUSTOM_STEP ? step.step : step.type;
+
+export const findStepDetails = (selection: StepSelection | ''): StepDetails =>
+  STEP_OPTIONS.find((step) => step.selection === selection) ?? EMPTY_STEP;

--- a/libs/audit/portal/builder/src/lib/step-property.model.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-property.model.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '@app-speed/audit/domain';
+import { STEP_SELECTION_OPTIONS_GROUPED } from './step-property.model';
+
+describe('STEP_SELECTION_OPTIONS_GROUPED', () => {
+  it('keeps custom steps in the unified selector with the audit grouping', () => {
+    expect(STEP_SELECTION_OPTIONS_GROUPED).toContainEqual({
+      label: 'Audit Steps',
+      icon: 'lighthouse-badge',
+      options: Object.values(LIGHTHOUSE_AUDIT_STEP_TYPE),
+    });
+  });
+});

--- a/libs/audit/portal/builder/src/lib/step-property.model.ts
+++ b/libs/audit/portal/builder/src/lib/step-property.model.ts
@@ -6,7 +6,7 @@ import {
   PUPPETEER_REPLAY_USER_STEP_TYPE,
 } from '@app-speed/audit/domain';
 
-const STEP_TYPE_OPTIONS_GROUPED = [
+export const STEP_SELECTION_OPTIONS_GROUPED = [
   {
     label: 'Audit Steps',
     icon: 'lighthouse-badge',
@@ -51,7 +51,7 @@ export const type = {
   name: PROPERTY_NAME.TYPE,
   inputType: INPUT_TYPE.OPTIONS,
   required: true,
-  options: ['', ...STEP_TYPE_OPTIONS_GROUPED],
+  options: ['', ...STEP_SELECTION_OPTIONS_GROUPED],
 } as const satisfies StepProperty;
 
 export const timeout = {

--- a/libs/audit/portal/data-access/src/lib/api-client.service.ts
+++ b/libs/audit/portal/data-access/src/lib/api-client.service.ts
@@ -5,7 +5,7 @@ import { Effect, ManagedRuntime, Schema } from 'effect';
 
 import { from } from 'rxjs';
 import { Api } from '@app-speed/audit/api-contract';
-import { AuditAuthoringSchema } from '@app-speed/audit/domain';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 @Injectable({ providedIn: 'root' })
 export class ApiClient {
@@ -25,7 +25,7 @@ export class ApiClient {
       this.runtime.runPromise(
         Effect.gen(function* () {
           const apiClient = yield* HttpApiClient.make(Api);
-          const payload = yield* Schema.decodeUnknown(AuditAuthoringSchema)(auditDetails);
+          const payload = yield* Schema.decodeUnknown(AuditSchema)(auditDetails);
           return yield* apiClient.audit.schedule({ payload });
         }),
       ),

--- a/libs/audit/portal/data-access/src/lib/api-client.service.ts
+++ b/libs/audit/portal/data-access/src/lib/api-client.service.ts
@@ -5,7 +5,7 @@ import { Effect, ManagedRuntime, Schema } from 'effect';
 
 import { from } from 'rxjs';
 import { Api } from '@app-speed/audit/api-contract';
-import { ReplayUserflowAuditSchema } from '@app-speed/audit/domain';
+import { AuditAuthoringSchema } from '@app-speed/audit/domain';
 
 @Injectable({ providedIn: 'root' })
 export class ApiClient {
@@ -25,7 +25,7 @@ export class ApiClient {
       this.runtime.runPromise(
         Effect.gen(function* () {
           const apiClient = yield* HttpApiClient.make(Api);
-          const payload = yield* Schema.decodeUnknown(ReplayUserflowAuditSchema)(auditDetails);
+          const payload = yield* Schema.decodeUnknown(AuditAuthoringSchema)(auditDetails);
           return yield* apiClient.audit.schedule({ payload });
         }),
       ),

--- a/libs/audit/runner/src/lib/audit/process-audit.ts
+++ b/libs/audit/runner/src/lib/audit/process-audit.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from 'effect';
 import { createRunner, parse as puppeteerReplayParse } from '@puppeteer/replay';
 import { generateReport, startFlow } from 'lighthouse';
 
-import { PuppeteerReplayUserflowRunnerSchema, ReplayUserflowAudit } from '@app-speed/audit/domain';
+import { AuditAuthoring, PuppeteerReplayUserflowRunnerSchema } from '@app-speed/audit/domain';
 
 import { DeviceConfiguration } from './device-configuration';
 import { RunnerContext } from './runner-context';
@@ -14,7 +14,7 @@ class RunnerError extends Schema.TaggedError<RunnerError>()('RunnerFailed', {
   cause: Schema.optional(Schema.Unknown),
 }) {}
 
-export const runAudit = Effect.fn((audit: ReplayUserflowAudit) =>
+export const runAudit = Effect.fn((audit: AuditAuthoring) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan({
       'audit.title': audit.title,

--- a/libs/audit/runner/src/lib/audit/process-audit.ts
+++ b/libs/audit/runner/src/lib/audit/process-audit.ts
@@ -2,7 +2,7 @@ import { Effect, Schema } from 'effect';
 import { createRunner, parse as puppeteerReplayParse } from '@puppeteer/replay';
 import { generateReport, startFlow } from 'lighthouse';
 
-import { AuditAuthoring, PuppeteerReplayUserflowRunnerSchema } from '@app-speed/audit/domain';
+import { Audit, PuppeteerReplayUserflowRunnerSchema } from '@app-speed/audit/domain';
 
 import { DeviceConfiguration } from './device-configuration';
 import { RunnerContext } from './runner-context';
@@ -14,7 +14,7 @@ class RunnerError extends Schema.TaggedError<RunnerError>()('RunnerFailed', {
   cause: Schema.optional(Schema.Unknown),
 }) {}
 
-export const runAudit = Effect.fn((audit: AuditAuthoring) =>
+export const runAudit = Effect.fn((audit: Audit) =>
   Effect.gen(function* () {
     yield* Effect.annotateCurrentSpan({
       'audit.title': audit.title,

--- a/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { UserFlow } from 'lighthouse';
+import { LIGHTHOUSE_AUDIT_STEP_TYPE } from '@app-speed/audit/domain';
+import { UserFlowRunnerExtension } from './runner-extension';
+
+const createFlow = () =>
+  ({
+    startNavigation: vi.fn().mockResolvedValue(undefined),
+    endNavigation: vi.fn().mockResolvedValue(undefined),
+    startTimespan: vi.fn().mockResolvedValue(undefined),
+    endTimespan: vi.fn().mockResolvedValue(undefined),
+    snapshot: vi.fn().mockResolvedValue(undefined),
+  }) as unknown as UserFlow;
+
+const createExtension = (flow: UserFlow) =>
+  new UserFlowRunnerExtension({} as never, {} as never, flow);
+
+describe('UserFlowRunnerExtension', () => {
+  it('dispatches each supported custom step exhaustively', async () => {
+    const flow = createFlow();
+    const extension = createExtension(flow);
+
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+        parameters: { name: 'Initial Navigation' },
+      },
+      {} as never,
+    );
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+        parameters: undefined,
+      },
+      {} as never,
+    );
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
+        parameters: { name: 'Profile Load' },
+      },
+      {} as never,
+    );
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
+        parameters: undefined,
+      },
+      {} as never,
+    );
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
+        parameters: { name: 'After Login' },
+      },
+      {} as never,
+    );
+
+    expect(flow.startNavigation).toHaveBeenCalledWith({ name: 'Initial Navigation' });
+    expect(flow.endNavigation).toHaveBeenCalledWith();
+    expect(flow.startTimespan).toHaveBeenCalledWith({ name: 'Profile Load' });
+    expect(flow.endTimespan).toHaveBeenCalledWith();
+    expect(flow.snapshot).toHaveBeenCalledWith({ name: 'After Login' });
+  });
+
+  it('rejects unsupported replay custom steps without the legacy generic fallback', async () => {
+    const flow = createFlow();
+    const extension = createExtension(flow);
+
+    await expect(
+      extension.runStep(
+        {
+          type: 'customStep',
+          name: 'unsupportedStep',
+          parameters: undefined,
+        } as never,
+        {} as never,
+      ),
+    ).rejects.toThrowError();
+
+    await extension
+      .runStep(
+        {
+          type: 'customStep',
+          name: 'unsupportedStep',
+          parameters: undefined,
+        } as never,
+        {} as never,
+      )
+      .catch((error: unknown) => {
+        expect(String(error)).not.toContain('Unknown custom step type');
+      });
+  });
+});

--- a/libs/audit/runner/src/lib/audit/runner-extension.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.ts
@@ -1,8 +1,10 @@
 import { PuppeteerRunnerExtension, Step, UserFlow as UserFlowRecording } from '@puppeteer/replay';
 import type { Browser, Page } from 'puppeteer';
 import type { UserFlow } from 'lighthouse';
-import { ReplayUserflowStepSchema, UserflowStepTypeWithStepFlagsLiteral } from '@app-speed/audit/domain';
+import { LIGHTHOUSE_AUDIT_STEP_TYPE, ReplayUserflowStepSchema } from '@app-speed/audit/domain';
 import { Schema } from 'effect';
+
+const decodeReplayUserflowStep = Schema.decodeUnknownSync(ReplayUserflowStepSchema);
 
 export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
   constructor(
@@ -20,21 +22,28 @@ export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
     step: Step | typeof ReplayUserflowStepSchema.Type,
     flowRecording: UserFlowRecording,
   ): Promise<void> {
-    if (Schema.is(ReplayUserflowStepSchema)(step)) {
-      return this.runCustomStep(step);
-    }
-
     if (step.type === 'customStep') {
-      throw new Error(`Unknown custom step type ${JSON.stringify(step)}`);
+      return this.runCustomStep(decodeReplayUserflowStep(step));
     }
 
     return super.runStep(step as Step, flowRecording);
   }
 
   async runCustomStep(step: typeof ReplayUserflowStepSchema.Type) {
-    if (Schema.is(UserflowStepTypeWithStepFlagsLiteral)(step.name)) {
-      return this.flow[step.name](step.parameters);
+    switch (step.name) {
+      case LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION:
+      case LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN:
+      case LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT:
+        return this.flow[step.name](step.parameters);
+      case LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION:
+      case LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN:
+        return this.flow[step.name]();
     }
-    return this.flow[step.name]();
+
+    return assertNever(step);
   }
 }
+
+const assertNever = (step: never): never => {
+  throw new Error(`Unsupported replay custom step: ${JSON.stringify(step)}`);
+};

--- a/libs/audit/runner/src/lib/queue/control-plane.effect.ts
+++ b/libs/audit/runner/src/lib/queue/control-plane.effect.ts
@@ -1,11 +1,11 @@
 import { EC2Client, StopInstancesCommand } from '@aws-sdk/client-ec2';
 import { HttpClient, HttpClientRequest, HttpClientResponse } from '@effect/platform';
 import { Clock, Config, Data, Effect, Match, Option, Schema } from 'effect';
-import { ReplayUserflowAuditSchema } from '@app-speed/audit/domain';
+import { AuditAuthoringSchema } from '@app-speed/audit/domain';
 
 export const AuditRequestSchema = Schema.Struct({
   auditId: Schema.String,
-  auditDetails: ReplayUserflowAuditSchema,
+  auditDetails: AuditAuthoringSchema,
 });
 export type AuditRequest = typeof AuditRequestSchema.Type;
 
@@ -14,7 +14,7 @@ const RunnerClaimResponseSchema = Schema.Union(
   Schema.Struct({
     available: Schema.Literal(true),
     auditId: Schema.String,
-    auditDetails: ReplayUserflowAuditSchema,
+    auditDetails: AuditAuthoringSchema,
   }),
 );
 

--- a/libs/audit/runner/src/lib/queue/control-plane.effect.ts
+++ b/libs/audit/runner/src/lib/queue/control-plane.effect.ts
@@ -1,11 +1,11 @@
 import { EC2Client, StopInstancesCommand } from '@aws-sdk/client-ec2';
 import { HttpClient, HttpClientRequest, HttpClientResponse } from '@effect/platform';
 import { Clock, Config, Data, Effect, Match, Option, Schema } from 'effect';
-import { AuditAuthoringSchema } from '@app-speed/audit/domain';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 export const AuditRequestSchema = Schema.Struct({
   auditId: Schema.String,
-  auditDetails: AuditAuthoringSchema,
+  auditDetails: AuditSchema,
 });
 export type AuditRequest = typeof AuditRequestSchema.Type;
 
@@ -14,7 +14,7 @@ const RunnerClaimResponseSchema = Schema.Union(
   Schema.Struct({
     available: Schema.Literal(true),
     auditId: Schema.String,
-    auditDetails: AuditAuthoringSchema,
+    auditDetails: AuditSchema,
   }),
 );
 

--- a/libs/audit/runner/src/test-data/test.json
+++ b/libs/audit/runner/src/test-data/test.json
@@ -2,13 +2,14 @@
   "title": "Example Title",
   "steps": [
     {
-      "type": "startNavigation",
-      "stepOptions": { "name": "Initial Navigation" }
+      "type": "customStep",
+      "step": "startNavigation",
+      "name": "Initial Navigation"
     },
     {
       "type": "navigate",
       "url": "https://google.com"
     },
-    { "type": "endNavigation" }
+    { "type": "customStep", "step": "endNavigation" }
   ]
 }


### PR DESCRIPTION
CLOSES: #136

## Checklist
- [x] Public audit/domain input no longer accepts replay-shaped custom-step payloads.
- [x] Supported custom steps are modeled as explicit authoring schemas with a dedicated discriminant and flattened step-specific fields.
- [x] Custom authoring steps are transformed into Puppeteer Replay `customStep` objects only at the runner boundary.
- [x] Lighthouse extension steps are modeled through the custom-step branch instead of separate top-level authoring step types.
- [x] Public schema and type naming reflects authoring-domain intent; replay-specific naming remains at the runner boundary.
- [x] Runner custom-step handling is compile-time exhaustive across supported custom steps.
- [ ] Portal custom-step metadata and support are compile-time exhaustive across supported custom steps.
- [x] The builder keeps a single grouped selector and still creates/renders the correct custom-step authoring shapes.
- [x] Domain tests cover explicit custom-step schema validation, transform behavior, and rejection of replay-shaped public input.
- [x] Runner tests cover exhaustive custom-step dispatch and removal of the generic unknown-step failure path.
- [ ] Portal tests cover grouped selector behavior, correct authoring object creation, and Lighthouse custom-step field rendering.
- [x] No new App Speed custom steps are implemented in this PR.
