### PR TITLE
[codex] unify user-flow replay states

### DIFF
--- a/apps/api/e2e/audit.e2e.ts
+++ b/apps/api/e2e/audit.e2e.ts
@@ -118,6 +118,22 @@ describe('Audit', () => {
     });
   });
 
+  it('should return run details by id for user-flow hydration', async () => {
+    const scheduleResponse = await ScheduleRequest(MOCK_AUDIT);
+    const res = await fetch(`${AUDIT_API_ENDPOINT}runs/${scheduleResponse.auditId}/details`);
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toMatchObject({
+      auditId: scheduleResponse.auditId,
+      audit: MOCK_AUDIT,
+      status: 'SCHEDULED',
+      resultStatus: null,
+    });
+    expect(body).toHaveProperty('queuePosition');
+    expect(body).toHaveProperty('createdAt');
+  });
+
   it('should return run not found for unknown run summary id', async () => {
     const res = await fetch(`${AUDIT_API_ENDPOINT}runs/STUB_ID`);
     const body = await res.json();
@@ -155,7 +171,12 @@ describe('Audit', () => {
 const MOCK_AUDIT = {
   title: 'Example Title',
   device: 'mobile',
-  steps: [{ type: 'startNavigation' }, { type: 'navigate', url: 'https://google.com' }, { type: 'endNavigation' }],
+  timeout: 30000,
+  steps: [
+    { type: 'customStep', step: 'startNavigation', name: 'Initial Navigation' },
+    { type: 'navigate', url: 'https://google.com' },
+    { type: 'customStep', step: 'endNavigation' },
+  ],
 };
 
 const AUDIT_API_ENDPOINT = 'http://localhost:3000/api/audit/';

--- a/apps/portal-e2e/e2e/audit-navigation.cy.ts
+++ b/apps/portal-e2e/e2e/audit-navigation.cy.ts
@@ -32,7 +32,7 @@ const createMockEventSource = () => {
 };
 
 describe('audit builder navigation (mock backend)', () => {
-  it('navigates to viewer with auditId and renders summary', () => {
+  it('navigates to canonical user-flow with auditId and renders summary', () => {
     const auditId = 'audit-smoke-123';
 
     cy.intercept('POST', '/api/audit/schedule', {
@@ -83,7 +83,7 @@ describe('audit builder navigation (mock backend)', () => {
     cy.wait('@schedule');
     cy.wait('@result');
 
-    cy.location('pathname').should('eq', '/user-flow/viewer');
+    cy.location('pathname').should('eq', '/user-flow');
     cy.location('search').should('contain', `auditId=${auditId}`);
     cy.get('ui-audit-summary', { timeout: 20000 }).should('be.visible');
   });

--- a/apps/portal/src/app/shell/shell.routes.ts
+++ b/apps/portal/src/app/shell/shell.routes.ts
@@ -10,14 +10,19 @@ export const shellRoutes: Route[] = [
         path: 'user-flow',
         children: [
           {
-            path: 'builder',
+            path: '',
             loadChildren: () => import('@app-speed/audit/portal/builder').then((m) => m.auditBuilderRoutes),
           },
           {
-            path: 'viewer',
-            loadComponent: () => import('@app-speed/audit/portal/viewer').then((m) => m.AuditViewerContainer),
+            path: 'builder',
+            redirectTo: '',
+            pathMatch: 'full',
           },
-          { path: '', redirectTo: 'builder', pathMatch: 'full' },
+          {
+            path: 'viewer',
+            redirectTo: '',
+            pathMatch: 'full',
+          },
         ],
       },
       {

--- a/libs/audit/api-contract/src/index.ts
+++ b/libs/audit/api-contract/src/index.ts
@@ -16,6 +16,7 @@ export {
 export { findByIdEndpoint, scheduleEndpoint, watchByIdEndpoint } from './lib/audit/builder/Api';
 export { AuditRunSummarySchema, AuditRunsQuerySchema, listRunsEndpoint, runByIdEndpoint } from './lib/audit/runs/Api';
 export { reportByIdEndpoint, resultByIdEndpoint } from './lib/audit/viewer/Api';
+export { runDetailsByIdEndpoint } from './lib/audit/runs/Api';
 
 export { HealthApiGroup } from './lib/health/Api';
 export { RunnerApiGroup } from './lib/runner/Api';

--- a/libs/audit/api-contract/src/lib/audit/Api.ts
+++ b/libs/audit/api-contract/src/lib/audit/Api.ts
@@ -1,7 +1,7 @@
 import { HttpApiGroup } from '@effect/platform';
 
 import { findByIdEndpoint, scheduleEndpoint, watchByIdEndpoint } from './builder/Api';
-import { listRunsEndpoint, runByIdEndpoint } from './runs/Api';
+import { listRunsEndpoint, runByIdEndpoint, runDetailsByIdEndpoint } from './runs/Api';
 import { reportByIdEndpoint, resultByIdEndpoint } from './viewer/Api';
 
 export class AuditApiGroup extends HttpApiGroup.make('audit')
@@ -11,5 +11,6 @@ export class AuditApiGroup extends HttpApiGroup.make('audit')
   .add(reportByIdEndpoint)
   .add(listRunsEndpoint)
   .add(runByIdEndpoint)
+  .add(runDetailsByIdEndpoint)
   .add(watchByIdEndpoint)
   .prefix('/audit') {}

--- a/libs/audit/api-contract/src/lib/audit/runs/Api.ts
+++ b/libs/audit/api-contract/src/lib/audit/runs/Api.ts
@@ -1,5 +1,6 @@
 import { HttpApiEndpoint } from '@effect/platform';
 import { Schema } from 'effect';
+import { AuditSchema } from '@app-speed/audit/domain';
 
 import {
   AuditId,
@@ -29,6 +30,18 @@ export const AuditRunSummarySchema = Schema.Struct({
   durationMs: Schema.NullOr(Schema.Number),
 });
 
+export const AuditRunDetailsSchema = Schema.Struct({
+  auditId: AuditId,
+  audit: AuditSchema,
+  status: AuditRunStatusSchema,
+  resultStatus: Schema.NullOr(AuditResultStatusSchema),
+  queuePosition: Schema.NullOr(Schema.NonNegativeInt),
+  createdAt: Schema.String,
+  startedAt: Schema.NullOr(Schema.String),
+  completedAt: Schema.NullOr(Schema.String),
+  durationMs: Schema.NullOr(Schema.Number),
+});
+
 const AuditRunsPageSchema = Schema.Struct({
   items: Schema.Array(AuditRunSummarySchema),
   nextCursor: Schema.NullOr(Schema.String),
@@ -45,5 +58,11 @@ export const listRunsEndpoint = HttpApiEndpoint.get('listRuns', '/runs')
 export const runByIdEndpoint = HttpApiEndpoint.get('runById', '/runs/:id')
   .setPath(Schema.Struct({ id: AuditId }))
   .addSuccess(AuditRunSummarySchema)
+  .addError(AuditRunSummaryNotFoundError)
+  .addError(AuditRunsInternalError);
+
+export const runDetailsByIdEndpoint = HttpApiEndpoint.get('runDetailsById', '/runs/:id/details')
+  .setPath(Schema.Struct({ id: AuditId }))
+  .addSuccess(AuditRunDetailsSchema)
   .addError(AuditRunSummaryNotFoundError)
   .addError(AuditRunsInternalError);

--- a/libs/audit/api-runtime/src/lib/audit/Http.ts
+++ b/libs/audit/api-runtime/src/lib/audit/Http.ts
@@ -3,7 +3,7 @@ import { Effect } from 'effect';
 import { Api } from '@app-speed/audit/api-contract';
 
 import { findByIdHandler, scheduleHandler, watchByIdHandler } from './builder/Http.js';
-import { listRunsHandler, runByIdHandler } from './runs/Http.js';
+import { listRunsHandler, runByIdHandler, runDetailsByIdHandler } from './runs/Http.js';
 import { reportByIdHandler, resultByIdHandler } from './viewer/Http.js';
 
 export const AuditGroupLive = HttpApiBuilder.group(Api, 'audit', (handlers) =>
@@ -16,6 +16,7 @@ export const AuditGroupLive = HttpApiBuilder.group(Api, 'audit', (handlers) =>
       .handle('schedule', scheduleHandler)
       .handle('listRuns', listRunsHandler)
       .handle('runById', runByIdHandler)
+      .handle('runDetailsById', runDetailsByIdHandler)
       .handle('watchById', watchByIdHandler);
   }),
 );

--- a/libs/audit/api-runtime/src/lib/audit/runs/Http.ts
+++ b/libs/audit/api-runtime/src/lib/audit/runs/Http.ts
@@ -1,6 +1,7 @@
 import { Effect } from 'effect';
 
 import { AuditRepo } from '@app-speed/audit/persistence';
+import type { Audit } from '@app-speed/audit/domain';
 
 import {
   AuditIdType,
@@ -176,6 +177,28 @@ const toRunSummaryResponse = (run: {
   durationMs: run.durationMs,
 });
 
+const toRunDetailsResponse = (run: {
+  id: AuditIdType;
+  data: Audit;
+  status: AuditRunStatus;
+  resultStatus: 'SUCCESS' | 'FAILURE' | null;
+  queuePosition: number | null;
+  createdAt: Date;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  durationMs: number | null;
+}) => ({
+  auditId: run.id,
+  audit: run.data,
+  status: run.status,
+  resultStatus: run.resultStatus,
+  queuePosition: run.queuePosition,
+  createdAt: run.createdAt.toISOString(),
+  startedAt: run.startedAt ? run.startedAt.toISOString() : null,
+  completedAt: run.completedAt ? run.completedAt.toISOString() : null,
+  durationMs: run.durationMs,
+});
+
 export const listRunsHandler = Effect.fn('api.audit.listRuns')((request) =>
   Effect.gen(function* () {
     const repo = yield* AuditRepo;
@@ -207,4 +230,20 @@ export const runByIdHandler = Effect.fn('api.audit.runById')((request) =>
 
     return toRunSummaryResponse(run);
   }).pipe(Effect.withSpan('api.audit.runById'), Effect.mapError(normalizeRunByIdError)),
+);
+
+export const runDetailsByIdHandler = Effect.fn('api.audit.runDetailsById')((request) =>
+  Effect.gen(function* () {
+    const repo = yield* AuditRepo;
+    const run = yield* repo.getRunDetailsById(request.path.id);
+    if (!run) {
+      return yield* new AuditRunSummaryNotFoundError({
+        code: 'RUN_NOT_FOUND',
+        message: `Audit run ${request.path.id} was not found.`,
+        details: { auditId: request.path.id },
+      });
+    }
+
+    return toRunDetailsResponse(run);
+  }).pipe(Effect.withSpan('api.audit.runDetailsById'), Effect.mapError(normalizeRunByIdError)),
 );

--- a/libs/audit/api-runtime/src/lib/runner/RunnerLifecycle.spec.ts
+++ b/libs/audit/api-runtime/src/lib/runner/RunnerLifecycle.spec.ts
@@ -17,6 +17,7 @@ const makeAuditRepoStub = (hasScheduledRuns: () => boolean) => ({
   markRunInProgress: () => unusedEffect,
   getQueuePosition: () => unusedEffect,
   getRunSummaryById: () => unusedEffect,
+  getRunDetailsById: () => unusedEffect,
   listRunsPage: () => unusedEffect,
   completeRun: () => unusedEffect,
   getRunById: () => unusedEffect,

--- a/libs/audit/persistence/src/lib/audit-repo.spec.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.spec.ts
@@ -82,6 +82,25 @@ layer(TestLayer)('AuditRepo (contract)', (it) => {
     }),
   );
 
+  it.effect('hydrates run details with the submitted audit snapshot', () =>
+    Effect.gen(function* () {
+      yield* resetDb;
+
+      const repo = yield* AuditRepo;
+
+      const templateId = yield* repo.createTemplate(sampleAudit);
+      const runId = yield* repo.createRun(templateId);
+      const runDetails = yield* repo.getRunDetailsById(runId);
+
+      expect(runDetails).not.toBeNull();
+      expect(runDetails?.id).toBe(runId);
+      expect(runDetails?.status).toBe('SCHEDULED');
+      expect(runDetails?.data).toEqual(sampleAudit);
+      expect(runDetails?.queuePosition).toBe(0);
+      expect(runDetails?.resultStatus).toBeNull();
+    }),
+  );
+
   it.effect('claims the next scheduled run and marks it in progress', () =>
     Effect.gen(function* () {
       yield* resetDb;

--- a/libs/audit/persistence/src/lib/audit-repo.ts
+++ b/libs/audit/persistence/src/lib/audit-repo.ts
@@ -5,8 +5,9 @@ import { Audit } from '@app-speed/audit/domain';
 import { DbClient, QueryError } from './db';
 import { createRun, createTemplate, getTemplateById } from './audit-repo/builder';
 import { claimNextRun, completeRun, getQueuePosition, hasScheduledRuns, markRunInProgress } from './audit-repo/queue';
-import { getRunSummaryById, listRunsPage } from './audit-repo/runs';
+import { getRunDetailsById, getRunSummaryById, listRunsPage } from './audit-repo/runs';
 import {
+  type AuditRunDetailsRecord,
   type AuditRunId,
   type AuditRunListCursor,
   type AuditRunRecord,
@@ -33,6 +34,9 @@ export class AuditRepo extends Context.Tag('AuditRepo')<
     getRunSummaryById: (
       id: AuditRunId,
     ) => Effect.Effect<AuditRunSummaryRecord | null, QueryError | ParseResult.ParseError>;
+    getRunDetailsById: (
+      id: AuditRunId,
+    ) => Effect.Effect<AuditRunDetailsRecord | null, QueryError | ParseResult.ParseError>;
     listRunsPage: (params: {
       limit: number;
       cursor: AuditRunListCursor | null;
@@ -71,6 +75,7 @@ export const AuditRepoLive = Layer.effect(
       markRunInProgress: (id: AuditRunId) => markRunInProgress(id).pipe(Effect.provideService(DbClient, db)),
       getQueuePosition: (id: AuditRunId) => getQueuePosition(id).pipe(Effect.provideService(DbClient, db)),
       getRunSummaryById: (id: AuditRunId) => getRunSummaryById(id).pipe(Effect.provideService(DbClient, db)),
+      getRunDetailsById: (id: AuditRunId) => getRunDetailsById(id).pipe(Effect.provideService(DbClient, db)),
       listRunsPage: (params: {
         limit: number;
         cursor: AuditRunListCursor | null;

--- a/libs/audit/persistence/src/lib/audit-repo/runs.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/runs.ts
@@ -8,6 +8,7 @@ import {
   type AuditRunListCursor,
   type AuditStatus,
   decodeAuditRunSummaryRecord,
+  decodeAuditRunDetailsRecord,
   resolveAuditTitle,
 } from './shared';
 import { getQueuePosition } from './queue';
@@ -44,6 +45,48 @@ export const getRunSummaryById = Effect.fn('db.auditRun.getSummaryById')(functio
   return yield* decodeAuditRunSummaryRecord({
     id: row.id,
     title: resolveAuditTitle(row.templateData),
+    status: row.status,
+    resultStatus: row.resultStatus ?? null,
+    queuePosition: row.status === 'SCHEDULED' ? (queuePosition ?? 0) : null,
+    createdAt: row.createdAt,
+    startedAt: row.startedAt,
+    completedAt: row.completedAt,
+    durationMs: row.durationMs,
+  });
+});
+
+export const getRunDetailsById = Effect.fn('db.auditRun.getDetailsById')(function* (id: AuditRunId) {
+  const db = yield* DbClient;
+  yield* Effect.annotateCurrentSpan({ 'audit.id': id });
+
+  const row = yield* db.run((client) =>
+    client
+      .select({
+        id: auditRunTable.id,
+        status: auditRunTable.status,
+        createdAt: auditRunTable.createdAt,
+        startedAt: auditRunTable.startedAt,
+        completedAt: auditRunTable.completedAt,
+        durationMs: auditRunTable.durationMs,
+        templateData: auditTemplateTable.data,
+        resultStatus: auditResultTable.status,
+      })
+      .from(auditRunTable)
+      .innerJoin(auditTemplateTable, eq(auditTemplateTable.id, auditRunTable.templateId))
+      .leftJoin(auditResultTable, eq(auditResultTable.runId, auditRunTable.id))
+      .where(eq(auditRunTable.id, id))
+      .get(),
+  );
+
+  if (!row) {
+    return null;
+  }
+
+  const queuePosition = row.status === 'SCHEDULED' ? yield* getQueuePosition(row.id as AuditRunId) : null;
+
+  return yield* decodeAuditRunDetailsRecord({
+    id: row.id,
+    data: row.templateData,
     status: row.status,
     resultStatus: row.resultStatus ?? null,
     queuePosition: row.status === 'SCHEDULED' ? (queuePosition ?? 0) : null,

--- a/libs/audit/persistence/src/lib/audit-repo/shared.ts
+++ b/libs/audit/persistence/src/lib/audit-repo/shared.ts
@@ -58,6 +58,19 @@ const AuditRunSummaryRecordSchema = Schema.Struct({
 });
 export type AuditRunSummaryRecord = typeof AuditRunSummaryRecordSchema.Type;
 
+const AuditRunDetailsRecordSchema = Schema.Struct({
+  id: AuditRunIdSchema,
+  data: AuditSchema,
+  status: AuditStatusSchema,
+  resultStatus: Schema.NullOr(AuditResultStatusSchema),
+  queuePosition: Schema.NullOr(Schema.NonNegativeInt),
+  createdAt: Schema.DateFromSelf,
+  startedAt: Schema.NullOr(Schema.DateFromSelf),
+  completedAt: Schema.NullOr(Schema.DateFromSelf),
+  durationMs: Schema.NullOr(Schema.Number),
+});
+export type AuditRunDetailsRecord = typeof AuditRunDetailsRecordSchema.Type;
+
 export const AuditRunListCursorSchema = Schema.Struct({
   createdAtMs: Schema.NonNegativeInt,
   id: Schema.String,
@@ -121,6 +134,29 @@ export const decodeAuditRunSummaryRecord = (run: {
   Schema.decodeUnknown(AuditRunSummaryRecordSchema, { errors: 'all' })({
     id: run.id,
     title: run.title,
+    status: run.status,
+    resultStatus: run.resultStatus,
+    queuePosition: run.queuePosition,
+    createdAt: run.createdAt,
+    startedAt: run.startedAt,
+    completedAt: run.completedAt,
+    durationMs: run.durationMs,
+  });
+
+export const decodeAuditRunDetailsRecord = (run: {
+  id: string;
+  data: unknown;
+  status: AuditStatus;
+  resultStatus: AuditResultStatus | null;
+  queuePosition: number | null;
+  createdAt: Date;
+  startedAt: Date | null;
+  completedAt: Date | null;
+  durationMs: number | null;
+}) =>
+  Schema.decodeUnknown(AuditRunDetailsRecordSchema, { errors: 'all' })({
+    id: run.id,
+    data: run.data,
     status: run.status,
     resultStatus: run.resultStatus,
     queuePosition: run.queuePosition,

--- a/libs/audit/portal/builder/package.json
+++ b/libs/audit/portal/builder/package.json
@@ -9,6 +9,7 @@
     "@angular/router": "21.2.13",
     "@app-speed/audit/portal/data-access": "0.0.1",
     "@app-speed/audit/portal/ui": "0.0.1",
+    "@app-speed/audit/portal/viewer": "0.0.1",
     "@app-speed/audit/domain": "0.0.1",
     "@ngrx/effects": "21.1.0",
     "@ngrx/store": "21.1.0",

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   DestroyRef,
+  computed,
   input,
   OnInit,
   output,
@@ -40,15 +41,21 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
               <input matInput placeholder="Audit Title" [formControl]="formGroup.controls.title" name="audit title" />
               <mat-error *rxIf="!!formGroup.controls.title.hasError">Title <strong>required</strong></mat-error>
             </mat-form-field>
-            <button
-              class="submit-btn"
-              mat-fab
-              [disabled]="formGroup.disabled || formGroup.invalid"
-              [extended]="true"
-              type="submit"
-            >
-              Analyze
-            </button>
+            @if (primaryAction() === 'analyze') {
+              <button
+                class="submit-btn"
+                mat-fab
+                [disabled]="formGroup.disabled || formGroup.invalid"
+                [extended]="true"
+                type="submit"
+              >
+                Analyze
+              </button>
+            } @else if (primaryAction() === 'fork') {
+              <button class="submit-btn" mat-fab [extended]="true" type="button" (click)="forked.emit()">Fork</button>
+            } @else {
+              <div class="submit-btn submit-btn--placeholder" aria-hidden="true"></div>
+            }
           </div>
           <div class="row">
             <mat-form-field class="full-width col">
@@ -74,7 +81,7 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
           </div>
           <mat-accordion [multi]="true">
             @for (step of formGroup.controls.steps.controls; track step) {
-              <ui-audit-builder-step [stepControl]="step">
+              <ui-audit-builder-step [stepControl]="step" [expanded]="stepExpanded()">
                 <div class="toggle-menu">
                   <button
                     type="button"
@@ -128,10 +135,14 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
 export class AuditBuilderComponent implements OnInit {
   public submitAudit = output<AuditDetails>();
   public readonly modified = output<AuditDetails>();
+  public readonly forked = output<void>();
   initialAudit = input.required<AuditDetails>();
   protected readonly DEVICE_TYPES: readonly string[] = DEVICE_OPTIONS;
   private readonly destroyRef = inject(DestroyRef);
   public readonly modifying = input.required<boolean>();
+  public readonly primaryAction = input<'analyze' | 'fork' | 'none'>('analyze');
+  public readonly collapseSteps = input(false);
+  protected readonly stepExpanded = computed(() => !this.collapseSteps());
 
   constructor() {
     effect(() => {

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.styles.scss
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.styles.scss
@@ -57,6 +57,12 @@
   }
 }
 
+.submit-btn--placeholder {
+  width: 56px;
+  height: 56px;
+  flex: 0 0 56px;
+}
+
 .toggle_menu {
   position: absolute;
   top: 48px;

--- a/libs/audit/portal/builder/src/lib/components/audit-step.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-step.component.ts
@@ -14,7 +14,7 @@ import { StepFieldsComponent } from './step-fields.component';
 @Component({
   selector: 'ui-audit-builder-step',
   template: `
-    <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel [expanded]="expanded()">
       @let control = stepControl();
       <mat-expansion-panel-header>
         <mat-panel-title>
@@ -98,6 +98,7 @@ import { StepFieldsComponent } from './step-fields.component';
 })
 export class AuditStepComponent {
   stepControl = input.required<StepFormGroup>();
+  expanded = input(true);
   private readonly destroyRef = inject(DestroyRef);
   protected readonly stepTypeOptions = STEP_SELECTION_OPTIONS_GROUPED;
 

--- a/libs/audit/portal/builder/src/lib/feature/builder.actions.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.actions.ts
@@ -55,8 +55,6 @@ export const loadAuditDetailsSuccess = createAction(
   props<{ audit: AuditDetails }>(),
 );
 
-export const loadAuditDetailsFailed = createAction('[Builder Page] Load Audit Details Failed');
-
 export const loadRunDetails = createAction('[Builder Page] Load Run Details', props<{ auditId: string }>());
 
 export const loadRunDetailsSuccess = createAction(
@@ -74,9 +72,6 @@ export const loadRunDetailsSuccess = createAction(
   }>(),
 );
 
-export const loadRunDetailsFailed = createAction(
-  '[Builder Page] Load Run Details Failed',
-  props<{ error: string }>(),
-);
+export const loadRunDetailsFailed = createAction('[Builder Page] Load Run Details Failed', props<{ error: string }>());
 
 export const forkAudit = createAction('[Builder Page] Fork Audit', props<{ audit: AuditDetails }>());

--- a/libs/audit/portal/builder/src/lib/feature/builder.actions.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.actions.ts
@@ -56,3 +56,27 @@ export const loadAuditDetailsSuccess = createAction(
 );
 
 export const loadAuditDetailsFailed = createAction('[Builder Page] Load Audit Details Failed');
+
+export const loadRunDetails = createAction('[Builder Page] Load Run Details', props<{ auditId: string }>());
+
+export const loadRunDetailsSuccess = createAction(
+  '[Builder Page] Load Run Details Success',
+  props<{
+    auditId: string;
+    audit: AuditDetails;
+    status: 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETE';
+    resultStatus: 'SUCCESS' | 'FAILURE' | null;
+    queuePosition: number | null;
+    createdAt: string;
+    startedAt: string | null;
+    completedAt: string | null;
+    durationMs: number | null;
+  }>(),
+);
+
+export const loadRunDetailsFailed = createAction(
+  '[Builder Page] Load Run Details Failed',
+  props<{ error: string }>(),
+);
+
+export const forkAudit = createAction('[Builder Page] Fork Audit', props<{ audit: AuditDetails }>());

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -112,7 +112,7 @@ export class BuilderComponent implements OnInit {
 
     return this.auditResultStatus() ? 'fork' : 'none';
   });
-  readonly collapseSteps = computed(() => this.auditResultStatus() === 'SUCCESS');
+  readonly collapseSteps = computed(() => this.requestId() !== null);
   readonly inlineError = computed(() => {
     if (this.auditResultStatus() === 'FAILURE') {
       return this.auditResultError() ?? this.auditRequestError() ?? 'Audit failed.';

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -81,30 +81,12 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
     .audit-status {
       max-width: 960px;
-      margin: 16px auto 0;
-      padding: 20px;
-      border-radius: 16px;
+      margin: auto;
     }
 
     .audit-status--error {
       border-color: #fecaca;
       background: #fff7f7;
-    }
-
-    .audit-status h2 {
-      margin: 0 0 8px;
-      font-size: 1.1rem;
-    }
-
-    .audit-status p {
-      margin: 0;
-      white-space: pre-wrap;
-    }
-
-    .audit-status small {
-      display: block;
-      margin-top: 12px;
-      color: #475569;
     }
   `,
   imports: [

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -7,6 +7,16 @@ import { auditBuilderFeature } from './builder.state';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { AuditBuilderComponent } from '../components/audit-builder.component';
 import { AuditViewerContainer } from '@app-speed/audit/portal/viewer';
+import { type StatusDialogModel } from '@app-speed/audit/portal/ui/dialogs';
+import {
+  MatCard,
+  MatCardContent,
+  MatCardFooter,
+  MatCardHeader,
+  MatCardSubtitle,
+  MatCardTitle,
+} from '@angular/material/card';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'audit',
@@ -23,12 +33,25 @@ import { AuditViewerContainer } from '@app-speed/audit/portal/viewer';
       />
 
       @if (loadingDialog(); as status) {
-        <section class="audit-status audit-status--progress" data-testid="audit-progress-status">
-          <h2>{{ status.title }}</h2>
-          <p>{{ status.subtitle }}</p>
-          @if (status.footerText; as footerText) {
-            <small>{{ footerText }}</small>
-          }
+        <section data-testid="audit-progress-status">
+          <mat-card class="status-card audit-status audit-status--progress">
+            <mat-card-header>
+              <mat-card-title>{{ status.title || 'loading...' }}</mat-card-title>
+              @if (status.subtitle) {
+                <mat-card-subtitle>{{ status.subtitle }}</mat-card-subtitle>
+              }
+            </mat-card-header>
+            <mat-card-content [style.padding-top]="'16px'">
+              <mat-spinner [diameter]="64" />
+            </mat-card-content>
+            @if (status.footerText) {
+              <mat-card-footer [style.padding]="'0 16px 0 16px'">
+                <p>
+                  <small>{{ status.footerText }}</small>
+                </p>
+              </mat-card-footer>
+            }
+          </mat-card>
         </section>
       }
 
@@ -51,19 +74,16 @@ import { AuditViewerContainer } from '@app-speed/audit/portal/viewer';
       display: block;
     }
 
-    .audit-status,
-    .audit-results {
+    .status-card {
+      align-items: center;
+      text-align: center;
+    }
+
+    .audit-status {
       max-width: 960px;
       margin: 16px auto 0;
       padding: 20px;
       border-radius: 16px;
-      background: #fff;
-      border: 1px solid #d9e2ec;
-      box-shadow: 0 12px 30px rgb(15 23 42 / 0.08);
-    }
-
-    .audit-status--progress {
-      border-color: #cbd5e1;
     }
 
     .audit-status--error {
@@ -87,7 +107,18 @@ import { AuditViewerContainer } from '@app-speed/audit/portal/viewer';
       color: #475569;
     }
   `,
-  imports: [AsyncPipe, AuditBuilderComponent, AuditViewerContainer],
+  imports: [
+    AsyncPipe,
+    AuditBuilderComponent,
+    AuditViewerContainer,
+    MatCard,
+    MatCardContent,
+    MatCardFooter,
+    MatCardHeader,
+    MatCardSubtitle,
+    MatCardTitle,
+    MatProgressSpinner,
+  ],
 })
 export class BuilderComponent implements OnInit {
   private readonly store = inject(Store);
@@ -95,7 +126,7 @@ export class BuilderComponent implements OnInit {
   public readonly modifying$ = this.store.select(auditBuilderFeature.selectModifying);
   public readonly modifying = toSignal(this.modifying$, { initialValue: true });
   private readonly loadingDialog$ = this.store.select(auditBuilderFeature.selectLoadingDialog);
-  readonly loadingDialog = toSignal(this.loadingDialog$, { initialValue: null });
+  readonly loadingDialog = toSignal<StatusDialogModel | null>(this.loadingDialog$, { initialValue: null });
   private readonly auditRequestError$ = this.store.select(auditBuilderFeature.selectAuditRequestError);
   readonly auditRequestError = toSignal(this.auditRequestError$, { initialValue: null });
   private readonly auditResultStatus$ = this.store.select(auditBuilderFeature.selectAuditResultStatus);

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -1,19 +1,12 @@
-import { Component, DestroyRef, inject, OnInit, signal, WritableSignal } from '@angular/core';
+import { Component, computed, inject, OnInit } from '@angular/core';
 import { Store } from '@ngrx/store';
-import { loadAuditDetails, submitAuditRequest, updateAuditDetails } from './builder.actions';
+import { forkAudit, loadAuditDetails, submitAuditRequest, updateAuditDetails } from './builder.actions';
 import { AuditDetails } from '../audit-details';
 import { AsyncPipe } from '@angular/common';
 import { auditBuilderFeature } from './builder.state';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import {
-  ErrorDialog,
-  StatusDialog,
-  type ErrorDialogModel,
-  type StatusDialogModel,
-} from '@app-speed/audit/portal/ui/dialogs';
-import { scan } from 'rxjs';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { AuditBuilderComponent } from '../components/audit-builder.component';
+import { AuditViewerContainer } from '@app-speed/audit/portal/viewer';
 
 @Component({
   selector: 'audit',
@@ -23,70 +16,117 @@ import { AuditBuilderComponent } from '../components/audit-builder.component';
         [modifying]="modifying()"
         (modified)="updateAuditDetails($event)"
         [initialAudit]="auditDetails"
+        [primaryAction]="primaryAction()"
+        [collapseSteps]="collapseSteps()"
         (submitAudit)="submitAudit($event)"
+        (forked)="forkCurrentAudit(auditDetails)"
       />
+
+      @if (loadingDialog(); as status) {
+        <section class="audit-status audit-status--progress" data-testid="audit-progress-status">
+          <h2>{{ status.title }}</h2>
+          <p>{{ status.subtitle }}</p>
+          @if (status.footerText; as footerText) {
+            <small>{{ footerText }}</small>
+          }
+        </section>
+      }
+
+      @if (inlineError(); as errorMessage) {
+        <section class="audit-status audit-status--error" data-testid="audit-inline-error">
+          <h2>Audit Failed</h2>
+          <p>{{ errorMessage }}</p>
+        </section>
+      }
+
+      @if (showResults()) {
+        <section class="audit-results" data-testid="audit-inline-results">
+          <viewer-container [auditId]="requestId()!" />
+        </section>
+      }
     }
   `,
-  imports: [AsyncPipe, AuditBuilderComponent],
+  styles: `
+    :host {
+      display: block;
+    }
+
+    .audit-status,
+    .audit-results {
+      max-width: 960px;
+      margin: 16px auto 0;
+      padding: 20px;
+      border-radius: 16px;
+      background: #fff;
+      border: 1px solid #d9e2ec;
+      box-shadow: 0 12px 30px rgb(15 23 42 / 0.08);
+    }
+
+    .audit-status--progress {
+      border-color: #cbd5e1;
+    }
+
+    .audit-status--error {
+      border-color: #fecaca;
+      background: #fff7f7;
+    }
+
+    .audit-status h2 {
+      margin: 0 0 8px;
+      font-size: 1.1rem;
+    }
+
+    .audit-status p {
+      margin: 0;
+      white-space: pre-wrap;
+    }
+
+    .audit-status small {
+      display: block;
+      margin-top: 12px;
+      color: #475569;
+    }
+  `,
+  imports: [AsyncPipe, AuditBuilderComponent, AuditViewerContainer],
 })
 export class BuilderComponent implements OnInit {
-  private readonly destroyRef = inject(DestroyRef);
   private readonly store = inject(Store);
   public readonly auditDetails$ = this.store.select(auditBuilderFeature.selectAudit);
   public readonly modifying$ = this.store.select(auditBuilderFeature.selectModifying);
   public readonly modifying = toSignal(this.modifying$, { initialValue: true });
-  private readonly auditLoadingDialog$ = this.store.select(auditBuilderFeature.selectLoadingDialog);
-
+  private readonly loadingDialog$ = this.store.select(auditBuilderFeature.selectLoadingDialog);
+  readonly loadingDialog = toSignal(this.loadingDialog$, { initialValue: null });
   private readonly auditRequestError$ = this.store.select(auditBuilderFeature.selectAuditRequestError);
-  private readonly dialog = inject(MatDialog);
+  readonly auditRequestError = toSignal(this.auditRequestError$, { initialValue: null });
+  private readonly auditResultStatus$ = this.store.select(auditBuilderFeature.selectAuditResultStatus);
+  readonly auditResultStatus = toSignal(this.auditResultStatus$, { initialValue: null });
+  private readonly auditResultError$ = this.store.select(auditBuilderFeature.selectAuditResultError);
+  readonly auditResultError = toSignal(this.auditResultError$, { initialValue: null });
+  private readonly requestId$ = this.store.select(auditBuilderFeature.selectRequestId);
+  readonly requestId = toSignal(this.requestId$, { initialValue: null });
+  readonly showResults = computed(() => this.auditResultStatus() === 'SUCCESS' && this.requestId() !== null);
+  readonly primaryAction = computed<'analyze' | 'fork' | 'none'>(() => {
+    if (this.modifying()) {
+      return 'analyze';
+    }
+
+    return this.auditResultStatus() ? 'fork' : 'none';
+  });
+  readonly collapseSteps = computed(() => this.auditResultStatus() === 'SUCCESS');
+  readonly inlineError = computed(() => {
+    if (this.auditResultStatus() === 'FAILURE') {
+      return this.auditResultError() ?? this.auditRequestError() ?? 'Audit failed.';
+    }
+
+    if (this.modifying()) {
+      return this.auditRequestError();
+    }
+
+    return null;
+  });
 
   ngOnInit() {
     this.store.dispatch(loadAuditDetails());
-
-    this.auditLoadingDialog$
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        scan(
-          (acc, loadingDialog) => {
-            if (acc.dialog && !loadingDialog) {
-              acc.dialog.close();
-              return { loading: null, dialog: null };
-            } else if (acc.dialog && acc.loading && loadingDialog) {
-              acc.loading.set(loadingDialog);
-              return acc;
-            }
-            if (loadingDialog) {
-              const loadingData = signal(loadingDialog);
-              return {
-                loading: loadingData,
-                dialog: this.dialog.open(StatusDialog, {
-                  data: loadingData,
-                  disableClose: true,
-                }),
-              };
-            }
-            return acc;
-          },
-          { loading: null, dialog: null } as {
-            loading: WritableSignal<StatusDialogModel> | null;
-            dialog: MatDialogRef<StatusDialog, unknown> | null;
-          },
-        ),
-      )
-      .subscribe();
-
-    this.auditRequestError$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((error) => {
-      if (error) {
-        const dialogData: ErrorDialogModel = {
-          title: 'Request Failed',
-          message: error,
-        };
-
-        this.dialog.open(ErrorDialog, {
-          data: dialogData,
-        });
-      }
-    });
   }
 
   submitAudit(audit: AuditDetails): void {
@@ -95,5 +135,9 @@ export class BuilderComponent implements OnInit {
 
   updateAuditDetails(audit: AuditDetails): void {
     this.store.dispatch(updateAuditDetails({ audit }));
+  }
+
+  forkCurrentAudit(audit: AuditDetails): void {
+    this.store.dispatch(forkAudit({ audit }));
   }
 }

--- a/libs/audit/portal/builder/src/lib/feature/builder.effects.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.effects.ts
@@ -6,18 +6,21 @@ import {
   auditResultRequested,
   auditResultSuccess,
   auditStageUpdated,
+  forkAudit,
   listenToAuditProgress,
   loadAuditDetails,
-  loadAuditDetailsFailed,
   loadAuditDetailsSuccess,
+  loadRunDetails,
+  loadRunDetailsFailed,
+  loadRunDetailsSuccess,
   submitAuditRequest,
   submitAuditRequestFailed,
   submitAuditRequestSuccess,
   updateAuditDetails,
 } from './builder.actions';
-import { catchError, debounceTime, distinctUntilChanged, filter, map, of, switchMap, tap } from 'rxjs';
+import { EMPTY, catchError, debounceTime, distinctUntilChanged, filter, map, of, switchMap, tap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
-import { DEFAULT_AUDIT_DETAILS } from '../audit-details';
+import { AuditDetails, DEFAULT_AUDIT_DETAILS } from '../audit-details';
 import { HttpClient } from '@angular/common/http';
 import type { FlowResult } from 'lighthouse';
 import { getAuditRequestErrorMessage } from './builder-error-message';
@@ -28,12 +31,37 @@ type AuditResultResponse =
   | { status: 'SUCCESS'; result: FlowResult }
   | { status: 'FAILURE'; error: { name: string; message: string; stack: string } };
 
+type RunDetailsResponse = {
+  auditId: string;
+  audit: AuditDetails;
+  status: 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETE';
+  resultStatus: 'SUCCESS' | 'FAILURE' | null;
+  queuePosition: number | null;
+  createdAt: string;
+  startedAt: string | null;
+  completedAt: string | null;
+  durationMs: number | null;
+};
+
 const loadAuditDetailsEffect = createEffect(
-  (actions$ = inject(Actions), activatedRoute = inject(ActivatedRoute)) => {
+  (actions$ = inject(Actions), activatedRoute = inject(ActivatedRoute), router = inject(Router)) => {
     return actions$.pipe(
       ofType(loadAuditDetails),
       map(() => {
+        const auditId = activatedRoute.snapshot.queryParams['auditId'];
         const auditDetailsQuery = activatedRoute.snapshot.queryParams['audit-details'];
+
+        if (auditId) {
+          if (auditDetailsQuery) {
+            router.navigate([], {
+              queryParams: { auditId },
+              replaceUrl: true,
+            });
+          }
+
+          return loadRunDetails({ auditId });
+        }
+
         if (auditDetailsQuery) {
           try {
             return loadAuditDetailsSuccess({ audit: JSON.parse(auditDetailsQuery) });
@@ -41,19 +69,10 @@ const loadAuditDetailsEffect = createEffect(
             // fall through to defaults below
           }
         }
-        return loadAuditDetailsFailed();
+        return loadAuditDetailsSuccess({ audit: DEFAULT_AUDIT_DETAILS });
       }),
     );
   },
-  { functional: true },
-);
-
-const loadAuditDetailsSuccessEffect = createEffect(
-  (actions$ = inject(Actions)) =>
-    actions$.pipe(
-      ofType(loadAuditDetailsSuccess),
-      map(({ audit }) => updateAuditDetails({ audit })),
-    ),
   { functional: true },
 );
 
@@ -65,20 +84,11 @@ const updateAuditDetailsEffect = createEffect(
       tap(({ audit }) =>
         router.navigate([], {
           queryParams: { ['audit-details']: JSON.stringify(audit) },
-          queryParamsHandling: 'replace',
+          replaceUrl: true,
         }),
       ),
     ),
   { functional: true, dispatch: false },
-);
-
-const loadAuditDetailsFailedEffect = createEffect(
-  (actions$ = inject(Actions)) =>
-    actions$.pipe(
-      ofType(loadAuditDetailsFailed),
-      map(() => updateAuditDetails({ audit: DEFAULT_AUDIT_DETAILS })),
-    ),
-  { functional: true },
 );
 
 const submitAuditRequestEffect = createEffect(
@@ -102,11 +112,63 @@ const submitAuditRequestEffect = createEffect(
   { functional: true },
 );
 
-const submitAuditRequestSuccessEffect = createEffect(
+const submitAuditRequestSuccessListenEffect = createEffect(
   (action$ = inject(Actions)) =>
     action$.pipe(
       ofType(submitAuditRequestSuccess),
       map(({ requestId }) => listenToAuditProgress({ requestId })),
+    ),
+  { functional: true },
+);
+
+const submitAuditRequestSuccessNavigateEffect = createEffect(
+  (actions$ = inject(Actions), router = inject(Router)) =>
+    actions$.pipe(
+      ofType(submitAuditRequestSuccess),
+      tap(({ requestId }) => {
+        router.navigate(['/user-flow'], {
+          queryParams: { auditId: requestId },
+        });
+      }),
+    ),
+  { functional: true, dispatch: false },
+);
+
+const loadRunDetailsEffect = createEffect(
+  (actions$ = inject(Actions), http = inject(HttpClient)) =>
+    actions$.pipe(
+      ofType(loadRunDetails),
+      switchMap(({ auditId }) =>
+        http.get<RunDetailsResponse>(`/api/audit/runs/${auditId}/details`).pipe(
+          map((runDetails) => loadRunDetailsSuccess(runDetails)),
+          catchError((error) =>
+            of(
+              loadRunDetailsFailed({
+                error: error?.error?.message ?? 'Unable to load the selected audit run.',
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  { functional: true },
+);
+
+const loadRunDetailsSuccessEffect = createEffect(
+  (actions$ = inject(Actions)) =>
+    actions$.pipe(
+      ofType(loadRunDetailsSuccess),
+      switchMap(({ auditId, status, resultStatus }) => {
+        if (status !== 'COMPLETE') {
+          return of(listenToAuditProgress({ requestId: auditId }));
+        }
+
+        if (resultStatus) {
+          return of(auditResultRequested({ requestId: auditId }));
+        }
+
+        return EMPTY;
+      }),
     ),
   { functional: true },
 );
@@ -184,13 +246,13 @@ const auditResultEffect = createEffect(
   { functional: true },
 );
 
-const auditResultSuccessNavigateEffect = createEffect(
+const forkAuditEffect = createEffect(
   (actions$ = inject(Actions), router = inject(Router)) =>
     actions$.pipe(
-      ofType(auditResultSuccess),
-      tap(({ requestId }) => {
-        router.navigate(['/user-flow/viewer'], {
-          queryParams: { auditId: requestId },
+      ofType(forkAudit),
+      tap(({ audit }) => {
+        router.navigate(['/user-flow'], {
+          queryParams: { ['audit-details']: JSON.stringify(audit) },
         });
       }),
     ),
@@ -202,12 +264,13 @@ export const provideBuilderEffects = () =>
     updateAuditDetailsEffect,
     submitAuditRequestEffect,
     loadAuditDetailsEffect,
-    loadAuditDetailsSuccessEffect,
-    loadAuditDetailsFailedEffect,
-    submitAuditRequestSuccessEffect,
+    loadRunDetailsEffect,
+    loadRunDetailsSuccessEffect,
+    submitAuditRequestSuccessListenEffect,
+    submitAuditRequestSuccessNavigateEffect,
     listenToAuditProgressEffect,
     listenToAuditQueuePositionEffect,
     auditResultRequestedEffect,
     auditResultEffect,
-    auditResultSuccessNavigateEffect,
+    forkAuditEffect,
   });

--- a/libs/audit/portal/builder/src/lib/feature/builder.state.spec.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.state.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_AUDIT_DETAILS } from '../audit-details';
 import {
   auditQueuePositionUpdated,
+  auditResultFailure,
   auditStageUpdated,
+  forkAudit,
   submitAuditRequest,
   submitAuditRequestSuccess,
 } from './builder.actions';
@@ -64,5 +66,31 @@ describe('auditBuilderReducer loading dialog states', () => {
       subtitle: 'A runner has started your audit. Results will open automatically when it completes.',
       footerText: 'Audit ID: audit-123',
     });
+  });
+
+  it('keeps the submitted form read-only when a completed run fails', () => {
+    const failedState = auditBuilderReducer(
+      auditBuilderReducer(initialState, submitAuditRequest({ audit: DEFAULT_AUDIT_DETAILS })),
+      auditResultFailure({ requestId: 'audit-123', error: 'Runner failed' }),
+    );
+
+    expect(failedState.modifying).toBe(false);
+    expect(failedState.auditStage).toBe('failed');
+    expect(failedState.auditResultStatus).toBe('FAILURE');
+  });
+
+  it('returns to editable draft mode when a completed run is forked', () => {
+    const forkedState = auditBuilderReducer(
+      auditBuilderReducer(
+        auditBuilderReducer(initialState, submitAuditRequest({ audit: DEFAULT_AUDIT_DETAILS })),
+        auditResultFailure({ requestId: 'audit-123', error: 'Runner failed' }),
+      ),
+      forkAudit({ audit: DEFAULT_AUDIT_DETAILS }),
+    );
+
+    expect(forkedState.modifying).toBe(true);
+    expect(forkedState.requestId).toBeNull();
+    expect(forkedState.auditResultStatus).toBeNull();
+    expect(forkedState.auditResultError).toBeNull();
   });
 });

--- a/libs/audit/portal/builder/src/lib/feature/builder.state.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.state.ts
@@ -6,7 +6,11 @@ import {
   auditResultRequested,
   auditResultSuccess,
   auditStageUpdated,
+  forkAudit,
   loadAuditDetailsSuccess,
+  loadRunDetails,
+  loadRunDetailsFailed,
+  loadRunDetailsSuccess,
   submitAuditRequest,
   submitAuditRequestFailed,
   submitAuditRequestSuccess,
@@ -15,6 +19,7 @@ import {
 import type { StatusDialogModel } from '@app-speed/audit/portal/ui/dialogs';
 import type { FlowResult } from 'lighthouse';
 import type { AuditStage } from './builder.actions';
+import { DEFAULT_AUDIT_DETAILS } from '../audit-details';
 
 export const auditBuilderFeatureKey = 'auditBuilder';
 
@@ -76,6 +81,25 @@ const getLoadingDialog = ({
   }
 
   return null;
+};
+
+const toAuditStage = (
+  status: 'SCHEDULED' | 'IN_PROGRESS' | 'COMPLETE',
+  resultStatus: 'SUCCESS' | 'FAILURE' | null,
+): AuditStage => {
+  if (status === 'SCHEDULED') {
+    return 'scheduled';
+  }
+
+  if (status === 'IN_PROGRESS') {
+    return 'running';
+  }
+
+  if (resultStatus === 'FAILURE') {
+    return 'failed';
+  }
+
+  return 'done';
 };
 
 export interface AuditBuilderState {
@@ -152,8 +176,8 @@ export const auditBuilderReducer = createReducer(
     queuePosition: null,
     listeningToAuditProgress: false,
     auditResult: null,
-    auditResultStatus: 'FAILURE',
-    auditResultError: auditRequestError,
+    auditResultStatus: null,
+    auditResultError: null,
     loadingDialog: null,
   })),
   on(auditStageUpdated, (state, { stage }) => {
@@ -201,7 +225,8 @@ export const auditBuilderReducer = createReducer(
     auditResultStatus: 'FAILURE',
     auditResultError: error,
     auditRequestError: error,
-    modifying: true,
+    modifying: false,
+    auditStage: 'failed',
     loadingDialog: null,
   })),
   on(updateAuditDetails, (state, { audit }) => ({
@@ -212,6 +237,90 @@ export const auditBuilderReducer = createReducer(
   on(loadAuditDetailsSuccess, (state, { audit }) => ({
     ...state,
     audit: audit,
+    modifying: true,
+    submittingRequest: false,
+    requestId: null,
+    queuePosition: null,
+    listeningToAuditProgress: false,
+    auditStage: null,
+    auditResult: null,
+    auditResultStatus: null,
+    auditResultError: null,
+    auditRequestError: null,
+    loadingDialog: null,
+  })),
+  on(loadRunDetails, (state, { auditId }) => ({
+    ...state,
+    audit: null,
+    modifying: false,
+    submittingRequest: true,
+    requestId: auditId,
+    queuePosition: null,
+    listeningToAuditProgress: null,
+    auditStage: 'scheduling',
+    auditResult: null,
+    auditResultStatus: null,
+    auditResultError: null,
+    auditRequestError: null,
+    loadingDialog: getLoadingDialog({
+      auditStage: 'scheduling',
+      queuePosition: null,
+      requestId: auditId,
+      submittingRequest: true,
+    }),
+  })),
+  on(loadRunDetailsSuccess, (state, { auditId, audit, status, resultStatus, queuePosition }) => {
+    const auditStage = toAuditStage(status, resultStatus);
+    const submittingRequest = auditStage === 'scheduled' || auditStage === 'running';
+    const nextState = {
+      ...state,
+      audit,
+      modifying: false,
+      submittingRequest,
+      requestId: auditId,
+      queuePosition,
+      listeningToAuditProgress: submittingRequest,
+      auditStage,
+      auditResult: null,
+      auditResultStatus: resultStatus,
+      auditResultError: resultStatus === 'FAILURE' ? state.auditResultError : null,
+      auditRequestError: resultStatus === 'FAILURE' ? state.auditRequestError : null,
+    };
+
+    return {
+      ...nextState,
+      loadingDialog: getLoadingDialog(nextState),
+    };
+  }),
+  on(loadRunDetailsFailed, (state, { error }) => ({
+    ...state,
+    audit: DEFAULT_AUDIT_DETAILS,
+    modifying: true,
+    submittingRequest: false,
+    requestId: null,
+    queuePosition: null,
+    listeningToAuditProgress: false,
+    auditStage: null,
+    auditResult: null,
+    auditResultStatus: null,
+    auditResultError: null,
+    auditRequestError: error,
+    loadingDialog: null,
+  })),
+  on(forkAudit, (state, { audit }) => ({
+    ...state,
+    audit,
+    modifying: true,
+    submittingRequest: false,
+    requestId: null,
+    queuePosition: null,
+    listeningToAuditProgress: false,
+    auditStage: null,
+    auditResult: null,
+    auditResultStatus: null,
+    auditResultError: null,
+    auditRequestError: null,
+    loadingDialog: null,
   })),
 );
 

--- a/libs/audit/portal/runs/src/lib/audit-run-details-page.component.spec.ts
+++ b/libs/audit/portal/runs/src/lib/audit-run-details-page.component.spec.ts
@@ -1,0 +1,63 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, convertToParamMap, Router } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { of } from 'rxjs';
+import { AuditRunDetailsPageComponent } from './audit-run-details-page.component';
+import { AuditRunsApiService } from './api/audit-runs-api.service';
+import type { AuditRunSummary } from './api/audit-runs.models';
+
+describe('AuditRunDetailsPageComponent', () => {
+  let fixture: ComponentFixture<AuditRunDetailsPageComponent>;
+  const navigate = vi.fn();
+  const getRun = vi.fn();
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    navigate.mockReset();
+    getRun.mockReset();
+
+    await TestBed.configureTestingModule({
+      imports: [AuditRunDetailsPageComponent],
+      providers: [
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            snapshot: { paramMap: convertToParamMap({ id: 'complete-audit' }) },
+            paramMap: of(convertToParamMap({ id: 'complete-audit' })),
+          },
+        },
+        { provide: AuditRunsApiService, useValue: { getRun } },
+        { provide: Router, useValue: { navigate } },
+      ],
+    }).compileComponents();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('redirects completed runs to the canonical user-flow route', async () => {
+    getRun.mockReturnValue(
+      of<AuditRunSummary>({
+        auditId: 'complete-audit',
+        title: 'Complete',
+        status: 'COMPLETE',
+        resultStatus: 'SUCCESS',
+        queuePosition: null,
+        createdAt: new Date().toISOString(),
+        startedAt: new Date().toISOString(),
+        completedAt: new Date().toISOString(),
+        durationMs: 1200,
+      }),
+    );
+
+    fixture = TestBed.createComponent(AuditRunDetailsPageComponent);
+    fixture.detectChanges();
+
+    await vi.advanceTimersByTimeAsync(5000);
+
+    expect(navigate).toHaveBeenCalledWith(['/user-flow'], {
+      queryParams: { auditId: 'complete-audit' },
+    });
+  });
+});

--- a/libs/audit/portal/runs/src/lib/audit-run-details-page.component.ts
+++ b/libs/audit/portal/runs/src/lib/audit-run-details-page.component.ts
@@ -68,7 +68,7 @@ export class AuditRunDetailsPageComponent {
 
         if (!this.#hasRedirected && run.status === 'COMPLETE' && run.resultStatus !== null) {
           this.#hasRedirected = true;
-          this.router.navigate(['/user-flow/viewer'], { queryParams: { auditId: run.auditId } });
+          this.router.navigate(['/user-flow'], { queryParams: { auditId: run.auditId } });
         }
       });
 

--- a/libs/audit/portal/runs/src/lib/audit-runs-page.component.spec.ts
+++ b/libs/audit/portal/runs/src/lib/audit-runs-page.component.spec.ts
@@ -52,7 +52,7 @@ describe('AuditRunsPageComponent', () => {
     vi.useRealTimers();
   });
 
-  it('navigates completed runs to viewer and active runs to details page', () => {
+  it('navigates completed runs to the canonical user-flow route and active runs to details page', () => {
     component.openRun({
       auditId: 'complete-audit',
       title: 'Complete',
@@ -65,7 +65,7 @@ describe('AuditRunsPageComponent', () => {
       durationMs: 1200,
     });
 
-    expect(navigate).toHaveBeenCalledWith(['/user-flow/viewer'], {
+    expect(navigate).toHaveBeenCalledWith(['/user-flow'], {
       queryParams: { auditId: 'complete-audit' },
     });
 

--- a/libs/audit/portal/runs/src/lib/audit-runs-page.component.ts
+++ b/libs/audit/portal/runs/src/lib/audit-runs-page.component.ts
@@ -118,7 +118,7 @@ export class AuditRunsPageComponent {
 
   openRun(run: AuditRunSummary) {
     if (run.status === 'COMPLETE') {
-      this.router.navigate(['/user-flow/viewer'], { queryParams: { auditId: run.auditId } });
+      this.router.navigate(['/user-flow'], { queryParams: { auditId: run.auditId } });
       return;
     }
 


### PR DESCRIPTION
## What changed
- made `/user-flow` the canonical audit page and redirected legacy `/user-flow/builder` and `/user-flow/viewer` URLs back into it
- added a dedicated audit run details API that returns the submitted audit snapshot together with run status metadata for page hydration
- unified the portal audit page so draft, queued/running, success, and failure states all render through one flow, including inline status, inline results, and fork behavior
- updated runs navigation and coverage to use the canonical `auditId` query-param flow

## Why
Issue #135 calls for removing the builder/viewer split and hydrating replay state from a single run-aware entry point. The previous route split forced separate navigation paths and made completed or in-flight runs harder to reopen consistently.

## Impact
- completed runs now open at `/user-flow?auditId=...`
- queued and running runs hydrate into the same page with read-only form state and status messaging
- completed runs can be forked from the same page instead of bouncing between separate builder and viewer routes

## Root cause
The portal treated authoring and replay/results as separate route surfaces while the backend only exposed partial run metadata for list/detail views. That left no supported way to reopen one canonical page from a persisted run.

## Validation
- `pnpm run lint:affected`
- `pnpm run test:affected`
- `pnpm run build:affected`
- `pnpm exec nx e2e api`
- `pnpm exec nx e2e portal-e2e`
