### PR TITLE
[codex] add waitForTime custom step

### DIFF
--- a/libs/audit/domain/src/index.ts
+++ b/libs/audit/domain/src/index.ts
@@ -16,7 +16,9 @@ export {
   AuditAddCookieStepSchema,
   AuditClearCacheStepSchema,
   AuditCustomRunnerStepSchema,
+  AuditSleepStepSchema,
   ReplayAuditCustomStepSchema,
+  SleepParametersSchema,
 } from './lib/custom-audit-step';
 export {
   isReplayUserflowStepWithFlags,

--- a/libs/audit/domain/src/index.ts
+++ b/libs/audit/domain/src/index.ts
@@ -16,9 +16,9 @@ export {
   AuditAddCookieStepSchema,
   AuditClearCacheStepSchema,
   AuditCustomRunnerStepSchema,
-  AuditSleepStepSchema,
+  AuditWaitForTimeStepSchema,
   ReplayAuditCustomStepSchema,
-  SleepParametersSchema,
+  WaitForTimeParametersSchema,
 } from './lib/custom-audit-step';
 export {
   isReplayUserflowStepWithFlags,

--- a/libs/audit/domain/src/lib/audit-step.schema.ts
+++ b/libs/audit/domain/src/lib/audit-step.schema.ts
@@ -34,7 +34,7 @@ export const LighthouseAuditStepTypeSchema = Schema.Literal(
 export const AppAuditCustomStepTypeSchema = Schema.Literal(
   AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE,
   AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE,
-  AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+  AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
 );
 
 export const AuditCustomStepTypeSchema = Schema.Union(LighthouseAuditStepTypeSchema, AppAuditCustomStepTypeSchema);

--- a/libs/audit/domain/src/lib/audit-step.schema.ts
+++ b/libs/audit/domain/src/lib/audit-step.schema.ts
@@ -34,6 +34,7 @@ export const LighthouseAuditStepTypeSchema = Schema.Literal(
 export const AppAuditCustomStepTypeSchema = Schema.Literal(
   AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE,
   AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE,
+  AUDIT_CUSTOM_STEP_TYPE.SLEEP,
 );
 
 export const AuditCustomStepTypeSchema = Schema.Union(LighthouseAuditStepTypeSchema, AppAuditCustomStepTypeSchema);

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -123,6 +123,46 @@ describe('PuppeteerReplayUserflowRunnerSchema', () => {
     });
   });
 
+  it('should decode sleep custom steps into replay parameters', () => {
+    const recording = {
+      title: 'Stub audit title',
+      device: 'mobile',
+      steps: [
+        {
+          type: 'customStep',
+          step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          seconds: 5,
+        },
+        {
+          type: 'customStep',
+          step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+          name: 'Home Page',
+        },
+      ],
+    };
+
+    const decoded = Schema.decodeUnknownSync(PuppeteerReplayUserflowRunnerSchema)(recording);
+
+    expect(decoded).toEqual({
+      title: 'Stub audit title',
+      device: 'mobile',
+      steps: [
+        {
+          type: 'customStep',
+          name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          parameters: {
+            seconds: 5,
+          },
+        },
+        {
+          type: 'customStep',
+          name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+          parameters: { name: 'Home Page' },
+        },
+      ],
+    });
+  });
+
   it('should decode normalized selector paths into replay-compatible selectors', () => {
     const recording = {
       title: 'Stub audit title',
@@ -220,6 +260,48 @@ describe('AuditSchema', () => {
         ],
       }),
     ).toBe(true);
+  });
+
+  it('should accept sleep persisted custom steps within one to sixty seconds', () => {
+    expect(
+      Schema.is(AuditSchema)({
+        title: 'Stub audit title',
+        device: 'mobile',
+        steps: [
+          {
+            type: 'customStep',
+            step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+            seconds: 60,
+          },
+          {
+            type: 'customStep',
+            step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it('should reject sleep persisted custom steps outside one to sixty seconds', () => {
+    const createAudit = (seconds: number) => ({
+      title: 'Stub audit title',
+      device: 'mobile',
+      steps: [
+        {
+          type: 'customStep',
+          step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          seconds,
+        },
+        {
+          type: 'customStep',
+          step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+        },
+      ],
+    });
+
+    expect(Schema.is(AuditSchema)(createAudit(0))).toBe(false);
+    expect(Schema.is(AuditSchema)(createAudit(61))).toBe(false);
+    expect(Schema.is(AuditSchema)(createAudit(1.5))).toBe(false);
   });
 
   it('should reject replay-shaped custom step input', () => {

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -123,14 +123,14 @@ describe('PuppeteerReplayUserflowRunnerSchema', () => {
     });
   });
 
-  it('should decode sleep custom steps into replay parameters', () => {
+  it('should decode waitForTime custom steps into replay parameters', () => {
     const recording = {
       title: 'Stub audit title',
       device: 'mobile',
       steps: [
         {
           type: 'customStep',
-          step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
           seconds: 5,
         },
         {
@@ -149,7 +149,7 @@ describe('PuppeteerReplayUserflowRunnerSchema', () => {
       steps: [
         {
           type: 'customStep',
-          name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
           parameters: {
             seconds: 5,
           },
@@ -262,7 +262,7 @@ describe('AuditSchema', () => {
     ).toBe(true);
   });
 
-  it('should accept sleep persisted custom steps within one to sixty seconds', () => {
+  it('should accept waitForTime persisted custom steps within one to sixty seconds', () => {
     expect(
       Schema.is(AuditSchema)({
         title: 'Stub audit title',
@@ -270,7 +270,7 @@ describe('AuditSchema', () => {
         steps: [
           {
             type: 'customStep',
-            step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+            step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
             seconds: 60,
           },
           {
@@ -282,14 +282,14 @@ describe('AuditSchema', () => {
     ).toBe(true);
   });
 
-  it('should reject sleep persisted custom steps outside one to sixty seconds', () => {
+  it('should reject waitForTime persisted custom steps outside one to sixty seconds', () => {
     const createAudit = (seconds: number) => ({
       title: 'Stub audit title',
       device: 'mobile',
       steps: [
         {
           type: 'customStep',
-          step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+          step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
           seconds,
         },
         {

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -4,7 +4,7 @@ import {
   AuditAddCookieStepSchema,
   AuditClearCacheStepSchema,
   AuditCustomRunnerStepSchema,
-  AuditSleepStepSchema,
+  AuditWaitForTimeStepSchema,
 } from './custom-audit-step';
 import { PuppeteerReplayRunnerStepSchema, PuppeteerReplayStepSchema } from './puppeteer-replay/puppeteer-replay-step';
 import { DeviceSchema } from './shared/device-type';
@@ -14,7 +14,7 @@ export const AuditStepSchema = Schema.Union(
   UserflowStepSchema,
   AuditClearCacheStepSchema,
   AuditAddCookieStepSchema,
-  AuditSleepStepSchema,
+  AuditWaitForTimeStepSchema,
 ).annotations({
   title: 'AuditStep',
 });

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -1,6 +1,11 @@
 import { Schema } from 'effect';
 import { UserflowRunnerStepSchema, UserflowStepSchema } from './lighthouse-userflow/lighthouse-userflow-step';
-import { AuditAddCookieStepSchema, AuditClearCacheStepSchema, AuditCustomRunnerStepSchema } from './custom-audit-step';
+import {
+  AuditAddCookieStepSchema,
+  AuditClearCacheStepSchema,
+  AuditCustomRunnerStepSchema,
+  AuditSleepStepSchema,
+} from './custom-audit-step';
 import { PuppeteerReplayRunnerStepSchema, PuppeteerReplayStepSchema } from './puppeteer-replay/puppeteer-replay-step';
 import { DeviceSchema } from './shared/device-type';
 
@@ -9,6 +14,7 @@ export const AuditStepSchema = Schema.Union(
   UserflowStepSchema,
   AuditClearCacheStepSchema,
   AuditAddCookieStepSchema,
+  AuditSleepStepSchema,
 ).annotations({
   title: 'AuditStep',
 });

--- a/libs/audit/domain/src/lib/builder-step-spec.spec.ts
+++ b/libs/audit/domain/src/lib/builder-step-spec.spec.ts
@@ -25,6 +25,7 @@ describe('builder step spec', () => {
       'snapshot',
       'clearCache',
       'addCookie',
+      'sleep',
     ]);
   });
 
@@ -142,6 +143,7 @@ describe('builder step spec', () => {
   it('keeps root discriminators structural and preserves legacy defaults', () => {
     const startNavigation = deriveBuilderStepSpec(findVariant('startNavigation'));
     const addCookie = deriveBuilderStepSpec(findVariant('addCookie'));
+    const sleep = deriveBuilderStepSpec(findVariant('sleep'));
 
     expect(startNavigation.discriminators).toEqual({
       type: 'customStep',
@@ -159,6 +161,20 @@ describe('builder step spec', () => {
       kind: 'enum',
       options: ['Strict', 'Lax', 'None'],
       required: false,
+    });
+    expect(sleep.defaultValue).toEqual({
+      type: 'customStep',
+      step: 'sleep',
+      seconds: 1,
+    });
+    expect(findField(sleep, 'seconds')).toMatchObject({
+      kind: 'number',
+      required: true,
+      validation: {
+        integer: true,
+        minimum: 1,
+        maximum: 60,
+      },
     });
   });
 

--- a/libs/audit/domain/src/lib/builder-step-spec.spec.ts
+++ b/libs/audit/domain/src/lib/builder-step-spec.spec.ts
@@ -25,7 +25,7 @@ describe('builder step spec', () => {
       'snapshot',
       'clearCache',
       'addCookie',
-      'sleep',
+      'waitForTime',
     ]);
   });
 
@@ -143,7 +143,7 @@ describe('builder step spec', () => {
   it('keeps root discriminators structural and preserves legacy defaults', () => {
     const startNavigation = deriveBuilderStepSpec(findVariant('startNavigation'));
     const addCookie = deriveBuilderStepSpec(findVariant('addCookie'));
-    const sleep = deriveBuilderStepSpec(findVariant('sleep'));
+    const waitForTime = deriveBuilderStepSpec(findVariant('waitForTime'));
 
     expect(startNavigation.discriminators).toEqual({
       type: 'customStep',
@@ -162,12 +162,12 @@ describe('builder step spec', () => {
       options: ['Strict', 'Lax', 'None'],
       required: false,
     });
-    expect(sleep.defaultValue).toEqual({
+    expect(waitForTime.defaultValue).toEqual({
       type: 'customStep',
-      step: 'sleep',
+      step: 'waitForTime',
       seconds: 1,
     });
-    expect(findField(sleep, 'seconds')).toMatchObject({
+    expect(findField(waitForTime, 'seconds')).toMatchObject({
       kind: 'number',
       required: true,
       validation: {

--- a/libs/audit/domain/src/lib/builder-step-spec.ts
+++ b/libs/audit/domain/src/lib/builder-step-spec.ts
@@ -10,6 +10,7 @@ export type BuilderStepVariantDefinition = {
 };
 export type BuilderFieldValidationSpec = {
   integer?: boolean;
+  maximum?: number;
   minItems?: number;
   minLength?: number;
   minimum?: number;
@@ -394,6 +395,10 @@ const deriveAnnotationValidationSpec = (
     validation.minimum = jsonSchema['minimum'];
   }
 
+  if (typeof jsonSchema['maximum'] === 'number') {
+    validation.maximum = jsonSchema['maximum'];
+  }
+
   if (typeof jsonSchema['pattern'] === 'string') {
     validation.pattern = jsonSchema['pattern'];
   }
@@ -447,6 +452,9 @@ const assignValidationValue = (
   switch (key) {
     case 'integer':
       target.integer = value as boolean;
+      break;
+    case 'maximum':
+      target.maximum = value as number;
       break;
     case 'minItems':
       target.minItems = value as number;

--- a/libs/audit/domain/src/lib/custom-audit-step-type.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step-type.ts
@@ -1,4 +1,5 @@
 export const AUDIT_CUSTOM_STEP_TYPE = {
   CLEAR_CACHE: 'clearCache',
   ADD_COOKIE: 'addCookie',
+  SLEEP: 'sleep',
 } as const;

--- a/libs/audit/domain/src/lib/custom-audit-step-type.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step-type.ts
@@ -1,5 +1,5 @@
 export const AUDIT_CUSTOM_STEP_TYPE = {
   CLEAR_CACHE: 'clearCache',
   ADD_COOKIE: 'addCookie',
-  SLEEP: 'sleep',
+  WAIT_FOR_TIME: 'waitForTime',
 } as const;

--- a/libs/audit/domain/src/lib/custom-audit-step.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step.ts
@@ -19,6 +19,10 @@ export const AddCookieParametersSchema = Schema.Struct({
   sameSite: Schema.optional(Schema.Literal('Strict', 'Lax', 'None')),
 });
 
+export const SleepParametersSchema = Schema.Struct({
+  seconds: Schema.Number.pipe(Schema.int(), Schema.between(1, 60)),
+});
+
 export const AuditClearCacheStepSchema = Schema.Struct({
   type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE)),
@@ -28,6 +32,12 @@ export const AuditAddCookieStepSchema = Schema.Struct({
   type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE)),
   ...AddCookieParametersSchema.fields,
+});
+
+export const AuditSleepStepSchema = Schema.Struct({
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.SLEEP)),
+  ...SleepParametersSchema.fields,
 });
 
 const ReplayAuditCustomStepWithoutFlagsSchema = Schema.Struct({
@@ -40,6 +50,12 @@ const ReplayAuditCustomStepWithFlagsSchema = Schema.Struct({
   type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE),
   parameters: AddCookieParametersSchema,
+});
+
+const ReplayAuditSleepStepSchema = Schema.Struct({
+  type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.SLEEP),
+  parameters: SleepParametersSchema,
 });
 
 const AuditClearCacheRunnerStepSchema = Schema.transform(
@@ -86,14 +102,30 @@ const AuditAddCookieRunnerStepSchema = Schema.transform(
   },
 );
 
+const AuditSleepRunnerStepSchema = Schema.transform(AuditSleepStepSchema, ReplayAuditSleepStepSchema, {
+  strict: true,
+  decode: ({ seconds }) => ({
+    type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+    name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+    parameters: { seconds },
+  }),
+  encode: ({ parameters }) => ({
+    type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+    step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+    ...parameters,
+  }),
+});
+
 export const ReplayAuditCustomStepSchema = Schema.Union(
   Schema.typeSchema(AuditClearCacheRunnerStepSchema),
   Schema.typeSchema(AuditAddCookieRunnerStepSchema),
+  Schema.typeSchema(AuditSleepRunnerStepSchema),
 );
 
 export const AuditCustomRunnerStepSchema = Schema.Union(
   AuditClearCacheRunnerStepSchema,
   AuditAddCookieRunnerStepSchema,
+  AuditSleepRunnerStepSchema,
 );
 
 export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefinition[] = [
@@ -114,6 +146,15 @@ export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefiniti
       name: '',
       value: '',
       url: '',
+    },
+  },
+  {
+    id: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+    schema: AuditSleepStepSchema,
+    defaultValue: {
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+      seconds: 1,
     },
   },
 ];

--- a/libs/audit/domain/src/lib/custom-audit-step.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step.ts
@@ -19,7 +19,7 @@ export const AddCookieParametersSchema = Schema.Struct({
   sameSite: Schema.optional(Schema.Literal('Strict', 'Lax', 'None')),
 });
 
-export const SleepParametersSchema = Schema.Struct({
+export const WaitForTimeParametersSchema = Schema.Struct({
   seconds: Schema.Number.pipe(Schema.int(), Schema.between(1, 60)),
 });
 
@@ -34,10 +34,10 @@ export const AuditAddCookieStepSchema = Schema.Struct({
   ...AddCookieParametersSchema.fields,
 });
 
-export const AuditSleepStepSchema = Schema.Struct({
+export const AuditWaitForTimeStepSchema = Schema.Struct({
   type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
-  step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.SLEEP)),
-  ...SleepParametersSchema.fields,
+  step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME)),
+  ...WaitForTimeParametersSchema.fields,
 });
 
 const ReplayAuditCustomStepWithoutFlagsSchema = Schema.Struct({
@@ -52,10 +52,10 @@ const ReplayAuditCustomStepWithFlagsSchema = Schema.Struct({
   parameters: AddCookieParametersSchema,
 });
 
-const ReplayAuditSleepStepSchema = Schema.Struct({
+const ReplayAuditWaitForTimeStepSchema = Schema.Struct({
   type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
-  name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.SLEEP),
-  parameters: SleepParametersSchema,
+  name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME),
+  parameters: WaitForTimeParametersSchema,
 });
 
 const AuditClearCacheRunnerStepSchema = Schema.transform(
@@ -102,30 +102,34 @@ const AuditAddCookieRunnerStepSchema = Schema.transform(
   },
 );
 
-const AuditSleepRunnerStepSchema = Schema.transform(AuditSleepStepSchema, ReplayAuditSleepStepSchema, {
-  strict: true,
-  decode: ({ seconds }) => ({
-    type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
-    name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
-    parameters: { seconds },
-  }),
-  encode: ({ parameters }) => ({
-    type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
-    step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
-    ...parameters,
-  }),
-});
+const AuditWaitForTimeRunnerStepSchema = Schema.transform(
+  AuditWaitForTimeStepSchema,
+  ReplayAuditWaitForTimeStepSchema,
+  {
+    strict: true,
+    decode: ({ seconds }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+      parameters: { seconds },
+    }),
+    encode: ({ parameters }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+      ...parameters,
+    }),
+  },
+);
 
 export const ReplayAuditCustomStepSchema = Schema.Union(
   Schema.typeSchema(AuditClearCacheRunnerStepSchema),
   Schema.typeSchema(AuditAddCookieRunnerStepSchema),
-  Schema.typeSchema(AuditSleepRunnerStepSchema),
+  Schema.typeSchema(AuditWaitForTimeRunnerStepSchema),
 );
 
 export const AuditCustomRunnerStepSchema = Schema.Union(
   AuditClearCacheRunnerStepSchema,
   AuditAddCookieRunnerStepSchema,
-  AuditSleepRunnerStepSchema,
+  AuditWaitForTimeRunnerStepSchema,
 );
 
 export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefinition[] = [
@@ -149,11 +153,11 @@ export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefiniti
     },
   },
   {
-    id: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
-    schema: AuditSleepStepSchema,
+    id: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+    schema: AuditWaitForTimeStepSchema,
     defaultValue: {
       type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
-      step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
       seconds: 1,
     },
   },

--- a/libs/audit/domain/src/lib/runtime/replay.ts
+++ b/libs/audit/domain/src/lib/runtime/replay.ts
@@ -52,6 +52,12 @@ interface AddCookieStep {
   sameSite?: 'Strict' | 'Lax' | 'None';
 }
 
+interface SleepStep {
+  type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
+  step: typeof AUDIT_CUSTOM_STEP_TYPE.SLEEP;
+  seconds: number;
+}
+
 type LighthouseStep =
   | StartNavigationStep
   | EndNavigationStep
@@ -59,7 +65,8 @@ type LighthouseStep =
   | EndTimespanStep
   | SnapshotStep
   | ClearCacheStep
-  | AddCookieStep;
+  | AddCookieStep
+  | SleepStep;
 
 export type AppSpeedUserFlowStep = PuppeteerReplayStep | LighthouseStep;
 

--- a/libs/audit/domain/src/lib/runtime/replay.ts
+++ b/libs/audit/domain/src/lib/runtime/replay.ts
@@ -52,9 +52,9 @@ interface AddCookieStep {
   sameSite?: 'Strict' | 'Lax' | 'None';
 }
 
-interface SleepStep {
+interface WaitForTimeStep {
   type: typeof PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP;
-  step: typeof AUDIT_CUSTOM_STEP_TYPE.SLEEP;
+  step: typeof AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME;
   seconds: number;
 }
 
@@ -66,7 +66,7 @@ type LighthouseStep =
   | SnapshotStep
   | ClearCacheStep
   | AddCookieStep
-  | SleepStep;
+  | WaitForTimeStep;
 
 export type AppSpeedUserFlowStep = PuppeteerReplayStep | LighthouseStep;
 

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -143,15 +143,15 @@ describe('StepFormGroup', () => {
     ]);
   });
 
-  it('selecting sleep produces a bounded required seconds field', () => {
+  it('selecting waitForTime produces a bounded required seconds field', () => {
     const formGroup = new StepFormGroup({ type: '' });
 
-    formGroup.resetStepControls(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
+    formGroup.resetStepControls(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME);
 
-    expect(formGroup.selectionControl.value).toBe(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
+    expect(formGroup.selectionControl.value).toBe(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME);
     expect(formGroup.getRawValue()).toEqual({
       type: 'customStep',
-      step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
       seconds: 1,
     });
     expect(formGroup.visibleFields(formGroup.spec.fields, formGroup).map((field) => field.path)).toEqual(['seconds']);

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -142,6 +142,21 @@ describe('StepFormGroup', () => {
       'httpOnly',
     ]);
   });
+
+  it('selecting sleep produces a bounded required seconds field', () => {
+    const formGroup = new StepFormGroup({ type: '' });
+
+    formGroup.resetStepControls(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
+
+    expect(formGroup.selectionControl.value).toBe(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
+    expect(formGroup.getRawValue()).toEqual({
+      type: 'customStep',
+      step: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+      seconds: 1,
+    });
+    expect(formGroup.visibleFields(formGroup.spec.fields, formGroup).map((field) => field.path)).toEqual(['seconds']);
+    expect(formGroup.optionalFields(formGroup.spec.fields, formGroup)).toEqual([]);
+  });
 });
 
 function findField(fields: readonly BuilderFieldSpec[], path: string): BuilderFieldSpec {

--- a/libs/audit/portal/builder/src/lib/components/step-fields.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/step-fields.component.ts
@@ -112,6 +112,9 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
               @if (asFormControl(fieldControl).hasError('min')) {
                 <mat-error>{{ labelFor(field) }} must stay above the minimum value</mat-error>
               }
+              @if (asFormControl(fieldControl).hasError('max')) {
+                <mat-error>{{ labelFor(field) }} must stay below the maximum value</mat-error>
+              }
               @if (asFormControl(fieldControl).hasError('integer')) {
                 <mat-error>{{ labelFor(field) }} must be an integer</mat-error>
               }

--- a/libs/audit/portal/builder/src/lib/step-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.spec.ts
@@ -56,13 +56,13 @@ describe('BuilderStepFormGroup', () => {
     const waitForExpression = createForm('waitForExpression');
     const navigate = createForm('navigate');
     const click = createForm('click');
-    const sleep = createForm(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
+    const waitForTime = createForm(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME);
     const selectorsField = expectArrayField(findField(click.spec.fields, 'selectors'));
 
     const expressionControl = waitForExpression.get('expression');
     const urlControl = navigate.get('url');
     const offsetXControl = click.get('offsetX');
-    const secondsControl = sleep.get('seconds');
+    const secondsControl = waitForTime.get('seconds');
 
     expect(expressionControl?.hasError('required')).toBe(true);
 

--- a/libs/audit/portal/builder/src/lib/step-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.spec.ts
@@ -1,5 +1,5 @@
 import { FormArray, FormGroup } from '@angular/forms';
-import type { BuilderFieldSpec } from '@app-speed/audit/domain';
+import { AUDIT_CUSTOM_STEP_TYPE, type BuilderFieldSpec } from '@app-speed/audit/domain';
 import { describe, expect, it } from 'vitest';
 import { BuilderStepFormGroup, findStepSpec } from './step-form';
 
@@ -56,11 +56,13 @@ describe('BuilderStepFormGroup', () => {
     const waitForExpression = createForm('waitForExpression');
     const navigate = createForm('navigate');
     const click = createForm('click');
+    const sleep = createForm(AUDIT_CUSTOM_STEP_TYPE.SLEEP);
     const selectorsField = expectArrayField(findField(click.spec.fields, 'selectors'));
 
     const expressionControl = waitForExpression.get('expression');
     const urlControl = navigate.get('url');
     const offsetXControl = click.get('offsetX');
+    const secondsControl = sleep.get('seconds');
 
     expect(expressionControl?.hasError('required')).toBe(true);
 
@@ -76,6 +78,15 @@ describe('BuilderStepFormGroup', () => {
     expect(offsetXControl?.hasError('min')).toBe(true);
     offsetXControl?.setValue(1.5);
     expect(offsetXControl?.hasError('integer')).toBe(true);
+
+    secondsControl?.setValue(0);
+    expect(secondsControl?.hasError('min')).toBe(true);
+    secondsControl?.setValue(61);
+    expect(secondsControl?.hasError('max')).toBe(true);
+    secondsControl?.setValue(1.5);
+    expect(secondsControl?.hasError('integer')).toBe(true);
+    secondsControl?.setValue(60);
+    expect(secondsControl?.valid).toBe(true);
 
     const selectorsControl = click.get('selectors') as FormArray<FormGroup>;
     click.addArrayItem(selectorsControl, selectorsField);

--- a/libs/audit/portal/builder/src/lib/step-form.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.ts
@@ -252,6 +252,10 @@ const buildScalarValidators = (
     validators.push(Validators.min(validation.minimum));
   }
 
+  if (typeof validation?.maximum === 'number') {
+    validators.push(Validators.max(validation.maximum));
+  }
+
   if (typeof validation?.pattern === 'string') {
     validators.push(Validators.pattern(validation.pattern));
   }

--- a/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
@@ -59,7 +59,7 @@ describe('step presentation registry', () => {
     expect(STEP_SELECTION_OPTIONS_GROUPED).toContainEqual({
       label: 'Custom Steps',
       icon: 'puppeteer-badge',
-      options: [AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE, AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE],
+      options: [AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE, AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE, AUDIT_CUSTOM_STEP_TYPE.SLEEP],
     });
   });
 

--- a/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
@@ -59,7 +59,11 @@ describe('step presentation registry', () => {
     expect(STEP_SELECTION_OPTIONS_GROUPED).toContainEqual({
       label: 'Custom Steps',
       icon: 'puppeteer-badge',
-      options: [AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE, AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE, AUDIT_CUSTOM_STEP_TYPE.SLEEP],
+      options: [
+        AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE,
+        AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE,
+        AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+      ],
     });
   });
 

--- a/libs/audit/portal/builder/src/lib/step-presentation.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.ts
@@ -88,6 +88,14 @@ export const AUDIT_BUILDER_STEP_PRESENTATION_REGISTRY = {
       },
     },
   },
+  sleep: {
+    fields: {
+      seconds: {
+        label: 'Seconds',
+        description: 'Duration to wait before the next step.',
+      },
+    },
+  },
 } as const satisfies Partial<Record<string, StepPresentationOverride>>;
 
 export const getStepPresentation = (variantId: string): StepPresentation => {

--- a/libs/audit/portal/builder/src/lib/step-presentation.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.ts
@@ -88,7 +88,7 @@ export const AUDIT_BUILDER_STEP_PRESENTATION_REGISTRY = {
       },
     },
   },
-  sleep: {
+  waitForTime: {
     fields: {
       seconds: {
         label: 'Seconds',

--- a/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
@@ -131,7 +131,7 @@ describe('UserFlowRunnerExtension', () => {
     });
   });
 
-  it('dispatches sleep custom steps through a bounded delay', async () => {
+  it('dispatches waitForTime custom steps through a bounded delay', async () => {
     vi.useFakeTimers();
 
     try {
@@ -143,7 +143,7 @@ describe('UserFlowRunnerExtension', () => {
         .runStep(
           {
             type: 'customStep',
-            name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+            name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
             parameters: {
               seconds: 2,
             },

--- a/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
@@ -131,6 +131,40 @@ describe('UserFlowRunnerExtension', () => {
     });
   });
 
+  it('dispatches sleep custom steps through a bounded delay', async () => {
+    vi.useFakeTimers();
+
+    try {
+      const flow = createFlow();
+      const extension = createExtension(flow);
+      let completed = false;
+
+      const result = extension
+        .runStep(
+          {
+            type: 'customStep',
+            name: AUDIT_CUSTOM_STEP_TYPE.SLEEP,
+            parameters: {
+              seconds: 2,
+            },
+          },
+          {} as never,
+        )
+        .then(() => {
+          completed = true;
+        });
+
+      await vi.advanceTimersByTimeAsync(1999);
+      expect(completed).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(result).resolves.toBeUndefined();
+      expect(completed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('propagates browser failures for clearCache and addCookie custom steps', async () => {
     const flow = createFlow();
     const clearCacheClient = {

--- a/libs/audit/runner/src/lib/audit/runner-extension.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.ts
@@ -8,6 +8,7 @@ import {
   ReplayUserflowStepSchema,
 } from '@app-speed/audit/domain';
 import { Schema } from 'effect';
+import { setTimeout as sleep } from 'node:timers/promises';
 
 const ReplayRunnerCustomStepSchema = Schema.Union(ReplayUserflowStepSchema, ReplayAuditCustomStepSchema);
 const decodeReplayRunnerCustomStep = Schema.decodeUnknownSync(ReplayRunnerCustomStepSchema);
@@ -48,6 +49,8 @@ export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
         return await this.page.createCDPSession().then((client) => client.send('Network.clearBrowserCache'));
       case AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE:
         return await this.page.setCookie(step.parameters);
+      case AUDIT_CUSTOM_STEP_TYPE.SLEEP:
+        return await sleep(step.parameters.seconds * 1000);
     }
 
     return assertNever(step);

--- a/libs/audit/runner/src/lib/audit/runner-extension.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.ts
@@ -8,7 +8,7 @@ import {
   ReplayUserflowStepSchema,
 } from '@app-speed/audit/domain';
 import { Schema } from 'effect';
-import { setTimeout as sleep } from 'node:timers/promises';
+import { setTimeout as waitForTime } from 'node:timers/promises';
 
 const ReplayRunnerCustomStepSchema = Schema.Union(ReplayUserflowStepSchema, ReplayAuditCustomStepSchema);
 const decodeReplayRunnerCustomStep = Schema.decodeUnknownSync(ReplayRunnerCustomStepSchema);
@@ -49,8 +49,8 @@ export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
         return await this.page.createCDPSession().then((client) => client.send('Network.clearBrowserCache'));
       case AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE:
         return await this.page.setCookie(step.parameters);
-      case AUDIT_CUSTOM_STEP_TYPE.SLEEP:
-        return await sleep(step.parameters.seconds * 1000);
+      case AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME:
+        return await waitForTime(step.parameters.seconds * 1000);
     }
 
     return assertNever(step);


### PR DESCRIPTION
## Summary

- Adds a `waitForTime` custom audit step with a required `seconds` parameter bounded from 1 to 60.
- Wires the step through domain schemas, runner transformation, builder metadata, and Angular form validation.
- Executes the runner delay with `node:timers/promises`.

## Validation

- `pnpm exec nx run-many --t lint build test`
- `pnpm exec nx run-many --targets=lint,build,test`
