### PR TITLE
fix(audit): keep pending runs recoverable

### DIFF
--- a/libs/audit/api-runtime/src/lib/runner/AwsRunnerManager.spec.ts
+++ b/libs/audit/api-runtime/src/lib/runner/AwsRunnerManager.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectAwsRunnerActivationAction } from './AwsRunnerManager.js';
+
+const instanceId = 'i-049287bf43503d01e' as never;
+const nowMs = Date.UTC(2026, 2, 7, 10, 0, 0);
+const startupGraceMs = 5 * 60 * 1000;
+
+describe('AwsRunnerManager activation decision', () => {
+  it('starts the configured runner instance when no EC2 instance is active', () => {
+    expect(
+      selectAwsRunnerActivationAction({
+        instances: [{ instanceId, state: 'stopped', launchedAt: new Date(nowMs - 60 * 60 * 1000) }],
+        registeredRunnerCount: 0,
+        nowMs,
+        startupGraceMs,
+        targetInstanceId: instanceId,
+      }),
+    ).toEqual({ action: 'start', instanceId });
+  });
+
+  it('waits for an active EC2 instance during startup grace before a runner heartbeat is observed', () => {
+    expect(
+      selectAwsRunnerActivationAction({
+        instances: [{ instanceId, state: 'running', launchedAt: new Date(nowMs - startupGraceMs + 1_000) }],
+        registeredRunnerCount: 0,
+        nowMs,
+        startupGraceMs,
+        targetInstanceId: instanceId,
+      }),
+    ).toEqual({ action: 'wait' });
+  });
+
+  it('recycles an active EC2 instance that has exceeded startup grace without a registered runner', () => {
+    expect(
+      selectAwsRunnerActivationAction({
+        instances: [{ instanceId, state: 'running', launchedAt: new Date(nowMs - startupGraceMs - 1_000) }],
+        registeredRunnerCount: 0,
+        nowMs,
+        startupGraceMs,
+        targetInstanceId: instanceId,
+      }),
+    ).toEqual({ action: 'recycle', instanceIds: [instanceId], targetInstanceId: instanceId });
+  });
+
+  it('keeps waiting when an active runner has checked in', () => {
+    expect(
+      selectAwsRunnerActivationAction({
+        instances: [{ instanceId, state: 'running', launchedAt: new Date(nowMs - startupGraceMs - 1_000) }],
+        registeredRunnerCount: 1,
+        nowMs,
+        startupGraceMs,
+        targetInstanceId: instanceId,
+      }),
+    ).toEqual({ action: 'wait' });
+  });
+});

--- a/libs/audit/api-runtime/src/lib/runner/AwsRunnerManager.ts
+++ b/libs/audit/api-runtime/src/lib/runner/AwsRunnerManager.ts
@@ -6,11 +6,12 @@ import {
   waitUntilInstanceRunning,
   waitUntilInstanceStopped,
 } from '@aws-sdk/client-ec2';
-import { Data, Effect, Either, Layer, Option, Schema } from 'effect';
+import { Clock, Data, Effect, Either, Layer, Option, Schema } from 'effect';
 import { RunnerIdSchema, RunnerManager, type ActiveRunnerList } from './RunnerManager.js';
 import { RunnerRegistry } from './RunnerRegistry.js';
 
 const DEFAULT_WAIT_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_STARTUP_GRACE_MS = 5 * 60 * 1000;
 const AWS_RUNNER_REGION = 'eu-central-1';
 const AWS_RUNNER_INSTANCE_IDS = ['i-049287bf43503d01e'] as const;
 
@@ -30,6 +31,7 @@ const ActiveEc2InstanceLifecycleStateSchema = Schema.Literal('pending', 'running
 const Ec2InstanceStateSchema = Schema.Struct({
   instanceId: Ec2InstanceIdSchema,
   state: Ec2InstanceLifecycleStateSchema,
+  launchedAt: Schema.NullOr(Schema.DateFromSelf),
 });
 
 const AwsRunnerManagerConfigSchema = Schema.Struct({
@@ -37,11 +39,16 @@ const AwsRunnerManagerConfigSchema = Schema.Struct({
   instanceIds: Schema.NonEmptyArray(Ec2InstanceIdSchema),
   startWaitTimeoutMs: Schema.Positive,
   stopWaitTimeoutMs: Schema.Positive,
+  startupGraceMs: Schema.Positive,
 });
 
 type Ec2InstanceId = typeof Ec2InstanceIdSchema.Type;
 type Ec2InstanceState = typeof Ec2InstanceStateSchema.Type;
 type AwsRunnerManagerConfig = typeof AwsRunnerManagerConfigSchema.Type;
+export type AwsRunnerActivationAction =
+  | { action: 'start'; instanceId: Ec2InstanceId }
+  | { action: 'wait' }
+  | { action: 'recycle'; instanceIds: ReadonlyArray<Ec2InstanceId>; targetInstanceId: Ec2InstanceId };
 
 class AwsRunnerManagerError extends Data.TaggedError('AwsRunnerManagerError')<{
   readonly message: string;
@@ -53,6 +60,7 @@ const awsRunnerManagerConfig = Schema.decodeUnknownSync(AwsRunnerManagerConfigSc
   instanceIds: [...AWS_RUNNER_INSTANCE_IDS],
   startWaitTimeoutMs: DEFAULT_WAIT_TIMEOUT_MS,
   stopWaitTimeoutMs: DEFAULT_WAIT_TIMEOUT_MS,
+  startupGraceMs: DEFAULT_STARTUP_GRACE_MS,
 });
 
 const decodeRunnerId = (value: string) => Schema.decodeSync(RunnerIdSchema)(value);
@@ -63,6 +71,43 @@ const decodeActiveLifecycleState = Schema.decodeUnknownEither(ActiveEc2InstanceL
 const toManagedRunnerId = (instanceId: Ec2InstanceId) => decodeRunnerId(`ec2-${instanceId}`);
 const isActiveEc2InstanceState = (state: Ec2InstanceState['state']): boolean =>
   Either.isRight(decodeActiveLifecycleState(state));
+
+export const selectAwsRunnerActivationAction = ({
+  instances,
+  registeredRunnerCount,
+  nowMs,
+  startupGraceMs,
+  targetInstanceId,
+}: {
+  instances: ReadonlyArray<Ec2InstanceState>;
+  registeredRunnerCount: number;
+  nowMs: number;
+  startupGraceMs: number;
+  targetInstanceId: Ec2InstanceId;
+}): AwsRunnerActivationAction => {
+  const activeInstances = instances.filter((instance) => isActiveEc2InstanceState(instance.state));
+
+  if (activeInstances.length === 0) {
+    return { action: 'start', instanceId: targetInstanceId };
+  }
+
+  if (registeredRunnerCount > 0) {
+    return { action: 'wait' };
+  }
+
+  const oldestLaunchMs = Math.min(...activeInstances.map((instance) => instance.launchedAt?.getTime() ?? 0));
+  const hasExceededStartupGrace = nowMs - oldestLaunchMs >= startupGraceMs;
+
+  if (!hasExceededStartupGrace) {
+    return { action: 'wait' };
+  }
+
+  return {
+    action: 'recycle',
+    instanceIds: activeInstances.map((instance) => instance.instanceId),
+    targetInstanceId,
+  };
+};
 
 const parseManagedInstanceId = (runnerId: string): Option.Option<Ec2InstanceId> => {
   const maybeInstanceId = decodeEc2InstanceId(runnerId);
@@ -102,6 +147,7 @@ const describeInstances = (
           const decodedState = decodeEc2InstanceState({
             instanceId: instance.InstanceId,
             state: instance.State?.Name ?? 'unknown',
+            launchedAt: instance.LaunchTime ?? null,
           });
           if (Either.isLeft(decodedState)) {
             return yield* new AwsRunnerManagerError({
@@ -203,22 +249,49 @@ export const AwsRunnerManagerLive = Layer.effect(
     const ensureRunnerActive = Effect.gen(function* () {
       const instances = yield* describeInstances(client, config.region, config.instanceIds);
       const activeInstances = instances.filter((instance) => isActiveEc2InstanceState(instance.state));
+      const registeredRunners = yield* runnerRegistry.listActiveRunners(
+        activeInstances.map((instance) => String(toManagedRunnerId(instance.instanceId))),
+      );
+      const nowMs = yield* Clock.currentTimeMillis;
+      const targetInstanceId = config.instanceIds[0];
+      const activationAction = selectAwsRunnerActivationAction({
+        instances,
+        registeredRunnerCount: registeredRunners.length,
+        nowMs,
+        startupGraceMs: config.startupGraceMs,
+        targetInstanceId,
+      });
+
       yield* Effect.annotateCurrentSpan({
         'runner.manager.mode': 'aws',
         'runner.aws.region': config.region,
         'runner.aws.instance_count': config.instanceIds.length,
         'runner.aws.active_count': activeInstances.length,
+        'runner.aws.registered_count': registeredRunners.length,
+        'runner.aws.activation_action': activationAction.action,
       });
 
-      if (activeInstances.length > 0) {
+      if (activationAction.action === 'wait') {
         return;
       }
 
-      const targetInstanceId = config.instanceIds[0];
+      if (activationAction.action === 'recycle') {
+        for (const instanceId of activationAction.instanceIds) {
+          yield* Effect.logInfo(`Runner lifecycle recycling unresponsive instance ${instanceId}`);
+          yield* stopInstance(client, instanceId, config.stopWaitTimeoutMs);
+          yield* runnerRegistry.markTerminated(String(toManagedRunnerId(instanceId)));
+        }
+      }
+
       yield* Effect.annotateCurrentSpan({
-        'runner.aws.starting_instance_id': targetInstanceId,
+        'runner.aws.starting_instance_id':
+          activationAction.action === 'start' ? activationAction.instanceId : activationAction.targetInstanceId,
       });
-      yield* startInstance(client, targetInstanceId, config.startWaitTimeoutMs);
+      yield* startInstance(
+        client,
+        activationAction.action === 'start' ? activationAction.instanceId : activationAction.targetInstanceId,
+        config.startWaitTimeoutMs,
+      );
     }).pipe(
       Effect.withSpan('runner.manager.ensureActive'),
       Effect.catchAll((error) =>

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
@@ -1,0 +1,69 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AuditProgressService } from './audit-progress.service';
+
+class FakeEventSource extends EventTarget {
+  static readonly CLOSED = 2;
+  static latest: FakeEventSource | null = null;
+
+  readyState = 0;
+
+  constructor(readonly url: string) {
+    super();
+    FakeEventSource.latest = this;
+  }
+
+  close(): void {
+    this.readyState = FakeEventSource.CLOSED;
+  }
+
+  emitMessage(eventName: string, data: unknown): void {
+    this.dispatchEvent(new MessageEvent(eventName, { data: JSON.stringify(data) }));
+  }
+
+  emitError(): void {
+    this.dispatchEvent(new Event('error'));
+  }
+}
+
+describe('AuditProgressService', () => {
+  beforeEach(() => {
+    FakeEventSource.latest = null;
+    vi.stubGlobal('EventSource', FakeEventSource);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AuditProgressService,
+        {
+          provide: HttpClient,
+          useValue: {
+            get: vi.fn(),
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not mark a pending audit as failed when the SSE transport reports an error', () => {
+    const service = TestBed.inject(AuditProgressService);
+    const stages: string[] = [];
+    service.stageName$.subscribe((stage) => stages.push(stage));
+
+    service.watchAudit('audit-123');
+
+    FakeEventSource.latest?.emitMessage('status', { auditId: 'audit-123', status: 'SCHEDULED' });
+    expect(stages.at(-1)).toBe('scheduled');
+
+    FakeEventSource.latest?.emitError();
+
+    expect(stages.at(-1)).toBe('scheduled');
+    expect(FakeEventSource.latest?.readyState).not.toBe(FakeEventSource.CLOSED);
+  });
+});

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
@@ -91,11 +91,8 @@ export class AuditProgressService {
     fromEvent<Event>(source, 'error')
       .pipe(takeUntil(this.disconnect$))
       .subscribe(() => {
-        source.close();
-        this.currentAuditId = null;
-        if (this.stage$.value !== 'done') {
-          this.stage$.next('failed');
-        }
+        // EventSource reports transient transport failures through `error` and reconnects automatically.
+        // Audit failure is signaled by the `result` event, not by the SSE connection state.
       });
   }
 }

--- a/libs/audit/portal/builder/src/lib/feature/builder.state.spec.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.state.spec.ts
@@ -68,6 +68,19 @@ describe('auditBuilderReducer loading dialog states', () => {
     });
   });
 
+  it('keeps the loading dialog visible while completed audit results are being finalized', () => {
+    const finalizingState = auditBuilderReducer(
+      auditBuilderReducer(initialState, submitAuditRequestSuccess({ requestId: 'audit-123', queuePosition: 0 })),
+      auditStageUpdated({ stage: 'done' }),
+    );
+
+    expect(finalizingState.loadingDialog).toEqual({
+      title: 'Finalizing audit',
+      subtitle: 'Preparing results.',
+      footerText: 'Audit ID: audit-123',
+    });
+  });
+
   it('keeps the submitted form read-only when a completed run fails', () => {
     const failedState = auditBuilderReducer(
       auditBuilderReducer(initialState, submitAuditRequest({ audit: DEFAULT_AUDIT_DETAILS })),

--- a/libs/audit/portal/builder/src/lib/feature/builder.state.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.state.ts
@@ -72,6 +72,14 @@ const getLoadingDialog = ({
     };
   }
 
+  if (auditStage === 'done') {
+    return {
+      title: 'Finalizing audit',
+      subtitle: 'Preparing results.',
+      footerText: getFooterText(requestId),
+    };
+  }
+
   if (auditStage === 'scheduled' || auditStage === 'scheduling') {
     return {
       title: 'Audit queued',


### PR DESCRIPTION
## Summary
- keep the audit progress indicator visible through transient SSE errors and result finalization
- recycle active AWS runner instances that never register after startup grace so scheduled audits can recover
- add regression coverage for frontend progress state and AWS runner activation decisions

## Testing
- pnpm exec nx test audit-portal-builder
- pnpm exec nx lint audit-portal-builder
- pnpm exec nx build audit-portal-builder
- pnpm exec nx test audit-api-runtime
- pnpm exec nx typecheck audit-api-runtime
- pnpm exec nx lint audit-api-runtime
- pnpm exec nx build audit-api-runtime