### PR TITLE
Install unzip in runner image for Puppeteer 25

### DIFF
--- a/apps/runner/Dockerfile
+++ b/apps/runner/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libxrender1 \
   libxss1 \
   libxtst6 \
+  unzip \
   xdg-utils \
   wget \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
- Add `unzip` to the runner Docker image so Puppeteer 25 can extract the downloaded Chrome bundle during build
- Fixes the deployment failure caused by the missing extraction binary in the `node:24-slim` image

## Testing
- Not run (not requested)