### PR TITLE
[codex] enforce runner deployment deadline

### DIFF
--- a/.github/workflows/deploy-runner.yml
+++ b/.github/workflows/deploy-runner.yml
@@ -120,7 +120,8 @@ jobs:
         id: ecr-login
         uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Publish and Deploy Runner
+      - name: Publish Runner Image
+        id: publish-runner
         env:
           ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
           DEPLOY_ENV: ${{ needs.determine-deploy-scope.outputs.deploy_env }}
@@ -132,6 +133,17 @@ jobs:
             IMAGE_REF="${ECR_REGISTRY}/app-speed/runner:dev-${GITHUB_SHA::12}-${RUN_SUFFIX}"
           fi
 
+          echo "image_ref=${IMAGE_REF}" >> "$GITHUB_OUTPUT"
           NX_DOCKER_IMAGE_REF="${IMAGE_REF}" pnpm exec nx release version --group=runner
           pnpm exec nx release publish --group=runner --yes --outputStyle=static
-          RUNNER_IMAGE_REF="${IMAGE_REF}" pnpm exec nx run runner:deploy --configuration="${DEPLOY_ENV}" --outputStyle=static --verbose
+
+      - name: Deploy Runner
+        timeout-minutes: 10
+        env:
+          DEPLOY_ENV: ${{ needs.determine-deploy-scope.outputs.deploy_env }}
+          IMAGE_REF: ${{ steps.publish-runner.outputs.image_ref }}
+        run: |
+          RUNNER_IMAGE_REF="${IMAGE_REF}" pnpm exec nx run runner:deploy \
+            --configuration="${DEPLOY_ENV}" \
+            --outputStyle=stream \
+            --verbose

--- a/apps/runner/project.json
+++ b/apps/runner/project.json
@@ -68,7 +68,7 @@
         "containerName": "app-speed-runner",
         "stopAfterCompletion": true,
         "stopOnlyIfStarted": false,
-        "expectBootstrapShutdown": true,
+        "expectBootstrapShutdown": false,
         "pruneDockerBeforePull": true,
         "pollIntervalMs": 5000,
         "startWaitTimeoutMs": 1800000,

--- a/tools/aws-deploy/src/lib/ssm.spec.ts
+++ b/tools/aws-deploy/src/lib/ssm.spec.ts
@@ -1,4 +1,3 @@
-import { waitUntilCommandExecuted } from '@aws-sdk/client-ssm';
 import type { SSMClient } from '@aws-sdk/client-ssm';
 import { waitForSsmCommandCompletion } from './ssm';
 
@@ -9,11 +8,8 @@ vi.mock('@aws-sdk/client-ssm', () => {
 
   return {
     GetCommandInvocationCommand,
-    waitUntilCommandExecuted: vi.fn(),
   };
 });
-
-const waitUntilCommandExecutedMock = vi.mocked(waitUntilCommandExecuted);
 
 describe('waitForSsmCommandCompletion', () => {
   beforeEach(() => {
@@ -21,8 +17,6 @@ describe('waitForSsmCommandCompletion', () => {
   });
 
   it('includes stderr details for failed invocations', async () => {
-    waitUntilCommandExecutedMock.mockResolvedValue({ state: 'FAILURE' } as never);
-
     const client = {
       send: vi.fn().mockResolvedValue({
         StatusDetails: 'Failed',
@@ -42,8 +36,6 @@ describe('waitForSsmCommandCompletion', () => {
   });
 
   it('includes current status and stdout when the invocation times out', async () => {
-    waitUntilCommandExecutedMock.mockRejectedValue(new Error('timed out'));
-
     const client = {
       send: vi.fn().mockResolvedValue({
         StatusDetails: 'InProgress',
@@ -53,10 +45,10 @@ describe('waitForSsmCommandCompletion', () => {
       }),
     } as unknown as SSMClient;
 
-    const result = await waitForSsmCommandCompletion(client, 'cmd-456', ['i-456'], 900000, 5000);
+    const result = await waitForSsmCommandCompletion(client, 'cmd-456', ['i-456'], 1, 1);
 
     expect(result.success).toBe(false);
-    expect(result.message).toContain('SSM command cmd-456 timed out after 900000ms');
+    expect(result.message).toContain('SSM command cmd-456 timed out after 1ms');
     expect(result.message).toContain('i-456=InProgress');
     expect(result.message).toContain('stdout="Pulling fs layer Pulling fs layer Download complete"');
   });

--- a/tools/aws-deploy/src/lib/ssm.ts
+++ b/tools/aws-deploy/src/lib/ssm.ts
@@ -1,4 +1,4 @@
-import { GetCommandInvocationCommand, SSMClient, waitUntilCommandExecuted } from '@aws-sdk/client-ssm';
+import { GetCommandInvocationCommand, SSMClient } from '@aws-sdk/client-ssm';
 
 export type SsmCommandCompletionResult = {
   success: boolean;
@@ -26,7 +26,13 @@ const isSuccessful = (status: string): boolean => normalizeStatus(status) === 's
 
 const isInProgress = (status: string): boolean => {
   const normalized = normalizeStatus(status);
-  return normalized === '' || normalized === 'pending' || normalized === 'inprogress' || normalized === 'delayed';
+  return (
+    normalized === '' ||
+    normalized === 'unknown' ||
+    normalized === 'pending' ||
+    normalized === 'inprogress' ||
+    normalized === 'delayed'
+  );
 };
 
 const summarizeOutput = (value?: string): string => {
@@ -61,8 +67,7 @@ const formatSnapshots = (snapshotsByInstance: Record<string, InvocationSnapshot>
     })
     .join(', ');
 
-const toWaitSeconds = (timeoutMs: number): number => Math.max(1, Math.ceil(timeoutMs / 1000));
-const toDelaySeconds = (pollIntervalMs: number): number => Math.max(1, Math.ceil(pollIntervalMs / 1000));
+const delay = (durationMs: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, durationMs));
 
 const getInvocationSnapshot = async (
   client: SSMClient,
@@ -104,56 +109,32 @@ export const waitForSsmCommandCompletion = async (
   pollIntervalMs: number,
   onProgress?: (message: string) => void,
 ): Promise<SsmCommandCompletionResult> => {
-  const maxWaitTime = toWaitSeconds(timeoutMs);
-  const delaySeconds = toDelaySeconds(pollIntervalMs);
+  const deadline = Date.now() + timeoutMs;
 
   const statuses = await Promise.all(
     instanceIds.map(async (instanceId) => {
       let lastProgress = '';
-      let progressInFlight = false;
-      const reportProgress = async (): Promise<void> => {
-        if (!onProgress || progressInFlight) {
-          return;
-        }
-
-        progressInFlight = true;
-        try {
-          const snapshot = await getInvocationSnapshot(client, commandId, instanceId);
+      while (true) {
+        const snapshot = await getInvocationSnapshot(client, commandId, instanceId);
+        if (onProgress) {
           const progress = formatSnapshots({ [instanceId]: snapshot });
           if (progress !== lastProgress) {
             lastProgress = progress;
             onProgress(`SSM command ${commandId} progress: ${progress}`);
           }
-        } finally {
-          progressInFlight = false;
         }
-      };
 
-      await reportProgress();
-      const progressTimer = onProgress ? setInterval(() => void reportProgress(), pollIntervalMs) : undefined;
-
-      try {
-        await waitUntilCommandExecuted(
-          {
-            client,
-            maxWaitTime,
-            minDelay: delaySeconds,
-            maxDelay: delaySeconds,
-          },
-          {
-            CommandId: commandId,
-            InstanceId: instanceId,
-          },
-        );
-      } catch {
-        // We still fetch the final invocation status below to build a precise message.
-      } finally {
-        if (progressTimer) {
-          clearInterval(progressTimer);
+        if (isSuccessful(snapshot.normalizedStatus) || !isInProgress(snapshot.normalizedStatus)) {
+          return [instanceId, snapshot] as const;
         }
+
+        const remainingMs = deadline - Date.now();
+        if (remainingMs <= 0) {
+          return [instanceId, snapshot] as const;
+        }
+
+        await delay(Math.min(pollIntervalMs, remainingMs));
       }
-
-      return [instanceId, await getInvocationSnapshot(client, commandId, instanceId)] as const;
     }),
   );
 


### PR DESCRIPTION
## Summary

- stop expecting the already-completed EC2 bootstrap shutdown on every deployment
- replace the AWS SDK SSM waiter with explicit wall-clock polling
- split image publishing from remote deployment
- enforce `timeout-minutes: 10` on the GitHub Actions deploy step
- use Nx streaming output so SSM progress is visible during execution

## Root cause

The 30-minute delay occurred before SSM execution. The runner target had `expectBootstrapShutdown: true` and `startWaitTimeoutMs: 1800000`, so every deployment waited for the instance to shut itself down after boot. That bootstrap shutdown did not occur because the instance had already completed bootstrap.

## Deadline enforcement

The runner now starts the existing instance and proceeds once it is running. The remote deployment also has two independent 10-minute limits:

- the executor stops SSM polling when `Date.now()` reaches its 600-second deadline
- GitHub Actions cancels the `Deploy Runner` step after 10 minutes regardless of executor behavior

Image build and publication occur before the bounded deploy step and are not included in its 10-minute window.

## Validation

- `pnpm exec nx test aws-deploy -- --run`
- `pnpm exec nx lint aws-deploy`
- `pnpm exec nx effect:diagnostics aws-deploy`
- `pnpm exec nx build runner`
- workflow YAML parsing, Prettier, and `git diff --check`