### PR TITLE
fix(audit): lock persisted result builders

### DIFF
--- a/libs/audit/portal/builder/src/lib/audit.routes.spec.ts
+++ b/libs/audit/portal/builder/src/lib/audit.routes.spec.ts
@@ -65,6 +65,42 @@ describe('auditBuilderRoutes', () => {
     http.verify();
   });
 
+  it('renders loaded result route audit details as read-only with a fork action', async () => {
+    await configureRouteTestingModule();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/user-flow/results/run-123', BuilderComponent);
+
+    const http = TestBed.inject(HttpTestingController);
+    const request = http.expectOne('/api/audit/runs/run-123/details');
+    request.flush({
+      auditId: 'run-123',
+      audit: DEFAULT_AUDIT_DETAILS,
+      status: 'SCHEDULED',
+      resultStatus: null,
+      queuePosition: 2,
+      createdAt: '2026-03-03T10:00:00.000Z',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    });
+    await harness.fixture.whenStable();
+
+    const root = harness.fixture.nativeElement as HTMLElement;
+    const auditCard = root.querySelector('[data-testid="audit-builder-card"]');
+    const auditTitle = root.querySelector<HTMLInputElement>('input[name="audit title"]');
+
+    expect(auditCard?.classList.contains('audit-card--readonly')).toBe(true);
+    expect(root.textContent).toContain('Fork');
+    expect(root.textContent).not.toContain('Analyze');
+    expect(auditTitle?.disabled).toBe(true);
+    expect(root.querySelector('button[aria-label="Toggle menu"]')).toBeNull();
+    expect(root.querySelector('button[aria-label="Add property to step"]')).toBeNull();
+    expect(root.querySelector('button[aria-label="Delete property from step"]')).toBeNull();
+
+    http.verify();
+  });
+
   it('redirects the bare results route to history', async () => {
     await configureRouteTestingModule();
 

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -157,6 +157,43 @@ describe('StepFormGroup', () => {
     expect(formGroup.visibleFields(formGroup.spec.fields, formGroup).map((field) => field.path)).toEqual(['seconds']);
     expect(formGroup.optionalFields(formGroup.spec.fields, formGroup)).toEqual([]);
   });
+
+  it('does not add or remove steps while the root audit form is disabled', () => {
+    const auditForm = new AuditFormGroup({
+      title: 'Checkout audit',
+      device: 'mobile',
+      timeout: 30000,
+      steps: [{ type: 'customStep', step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME, seconds: 1 }],
+    });
+
+    auditForm.disable();
+    auditForm.addStepAt(0);
+    auditForm.removeStepAt(0);
+
+    expect(auditForm.controls.steps.length).toBe(1);
+    expect(auditForm.getRawValue().steps).toEqual([
+      { type: 'customStep', step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME, seconds: 1 },
+    ]);
+  });
+
+  it('disables the step type selector and refuses type resets while the step form is disabled', () => {
+    const formGroup = new StepFormGroup({
+      type: 'customStep',
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+      seconds: 1,
+    });
+
+    formGroup.disable();
+    formGroup.resetStepControls(AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE);
+
+    expect(formGroup.selectionControl.disabled).toBe(true);
+    expect(formGroup.selectionControl.value).toBe(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME);
+    expect(formGroup.getRawValue()).toEqual({
+      type: 'customStep',
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+      seconds: 1,
+    });
+  });
 });
 
 function findField(fields: readonly BuilderFieldSpec[], path: string): BuilderFieldSpec {

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.ts
@@ -34,10 +34,18 @@ export class AuditFormGroup extends FormGroup<{
   }
 
   addStepAt(index: number) {
+    if (this.disabled || this.controls.steps.disabled) {
+      return;
+    }
+
     this.controls.steps.insert(index, new StepFormGroup({ type: '' }));
   }
 
   removeStepAt(index: number) {
+    if (this.disabled || this.controls.steps.disabled) {
+      return;
+    }
+
     this.controls.steps.removeAt(index);
   }
 }
@@ -58,6 +66,10 @@ export class StepFormGroup extends BuilderStepFormGroup {
   }
 
   resetStepControls(stepSelection: StepSelection | '', step?: AuditStep): void {
+    if (this.disabled) {
+      return;
+    }
+
     if (this.selectionControl.value !== stepSelection) {
       this.selectionControl.setValue(stepSelection, { emitEvent: false });
     }
@@ -68,6 +80,16 @@ export class StepFormGroup extends BuilderStepFormGroup {
     }
 
     this.resetSpec(findStepSpec(stepSelection), step as Record<string, unknown> | undefined);
+  }
+
+  override disable(opts?: { onlySelf?: boolean; emitEvent?: boolean }): void {
+    super.disable(opts);
+    this.selectionControl.disable(opts);
+  }
+
+  override enable(opts?: { onlySelf?: boolean; emitEvent?: boolean }): void {
+    super.enable(opts);
+    this.selectionControl.enable(opts);
   }
 }
 

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
@@ -33,7 +33,7 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
   selector: 'ui-audit-builder',
   template: `
     <form class="grid-container" [formGroup]="formGroup" (ngSubmit)="submitAudit.emit(auditValue())">
-      <mat-card>
+      <mat-card class="audit-card" [class.audit-card--readonly]="!modifying()" data-testid="audit-builder-card">
         <mat-card-content>
           <div class="row">
             <mat-form-field class="full-width">
@@ -82,25 +82,26 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
           <mat-accordion [multi]="true">
             @for (step of formGroup.controls.steps.controls; track step) {
               <ui-audit-builder-step [stepControl]="step" [expanded]="stepExpanded()">
-                <div class="toggle-menu">
-                  <button
-                    type="button"
-                    mat-icon-button
-                    class="toggle_menu"
-                    aria-label="Toggle menu"
-                    [matMenuTriggerFor]="menu"
-                    [disabled]="formGroup.disabled"
-                  >
-                    <mat-icon>more_vert</mat-icon>
-                  </button>
-                  <mat-menu #menu="matMenu" xPosition="before">
-                    <button type="button" mat-menu-item (click)="formGroup.removeStepAt($index)">Remove Step</button>
-                    <button type="button" mat-menu-item (click)="formGroup.addStepAt($index)">Add Step Before</button>
-                    <button type="button" mat-menu-item (click)="formGroup.addStepAt($index + 1)">
-                      Add Step After
+                @if (formGroup.enabled) {
+                  <div class="toggle-menu">
+                    <button
+                      type="button"
+                      mat-icon-button
+                      class="toggle_menu"
+                      aria-label="Toggle menu"
+                      [matMenuTriggerFor]="menu"
+                    >
+                      <mat-icon>more_vert</mat-icon>
                     </button>
-                  </mat-menu>
-                </div>
+                    <mat-menu #menu="matMenu" xPosition="before">
+                      <button type="button" mat-menu-item (click)="formGroup.removeStepAt($index)">Remove Step</button>
+                      <button type="button" mat-menu-item (click)="formGroup.addStepAt($index)">Add Step Before</button>
+                      <button type="button" mat-menu-item (click)="formGroup.addStepAt($index + 1)">
+                        Add Step After
+                      </button>
+                    </mat-menu>
+                  </div>
+                }
               </ui-audit-builder-step>
             }
           </mat-accordion>
@@ -146,16 +147,13 @@ export class AuditBuilderComponent implements OnInit {
 
   constructor() {
     effect(() => {
-      if (this.modifying()) {
-        this.formGroup.enable();
-      } else {
-        this.formGroup.disable();
-      }
+      this.syncFormMode(this.modifying());
     });
   }
 
   ngOnInit(): void {
     this.formGroup = new AuditFormGroup(this.initialAudit());
+    this.syncFormMode(this.modifying());
 
     this.formGroup.valueChanges
       .pipe(
@@ -169,5 +167,17 @@ export class AuditBuilderComponent implements OnInit {
 
   protected auditValue(): AuditDetails {
     return this.formGroup.getRawValue() as unknown as AuditDetails;
+  }
+
+  private syncFormMode(modifying: boolean): void {
+    if (!this.formGroup) {
+      return;
+    }
+
+    if (modifying) {
+      this.formGroup.enable();
+    } else {
+      this.formGroup.disable();
+    }
   }
 }

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.styles.scss
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.styles.scss
@@ -36,6 +36,21 @@
   flex-direction: row;
 }
 
+.audit-card {
+  border: 1px solid transparent;
+}
+
+.audit-card--readonly {
+  border-color: #b7c8d8;
+  border-left: 6px solid #2f6f9f;
+  background:
+    linear-gradient(90deg, rgba(47, 111, 159, 0.08), transparent 120px),
+    #f8fbfd;
+  box-shadow:
+    inset 0 0 0 1px rgba(47, 111, 159, 0.08),
+    0 3px 10px rgba(26, 54, 77, 0.08);
+}
+
 .card-content {
   margin: 20px auto;
 }

--- a/libs/audit/portal/builder/src/lib/components/step-fields.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/step-fields.component.ts
@@ -49,7 +49,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
       }
 
       @let optional = optionalFields();
-      @if (optional.length > 0) {
+      @if (control().enabled && optional.length > 0) {
         <div class="optional-fields">
           <h4>Optional Properties</h4>
           <div class="optional-fields__actions">
@@ -86,7 +86,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 <mat-error>{{ labelFor(field) }} does not match the expected format</mat-error>
               }
             </mat-form-field>
-            @if (!field.required) {
+            @if (control().enabled && !field.required) {
               <button
                 mat-icon-button
                 aria-label="Delete property from step"
@@ -119,7 +119,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 <mat-error>{{ labelFor(field) }} must be an integer</mat-error>
               }
             </mat-form-field>
-            @if (!field.required) {
+            @if (control().enabled && !field.required) {
               <button
                 mat-icon-button
                 aria-label="Delete property from step"
@@ -143,7 +143,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 <mat-hint>{{ description }}</mat-hint>
               }
             </mat-form-field>
-            @if (!field.required) {
+            @if (control().enabled && !field.required) {
               <button
                 mat-icon-button
                 aria-label="Delete property from step"
@@ -171,7 +171,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 <mat-error>{{ labelFor(field) }} is required</mat-error>
               }
             </mat-form-field>
-            @if (!field.required) {
+            @if (control().enabled && !field.required) {
               <button
                 mat-icon-button
                 aria-label="Delete property from step"
@@ -203,7 +203,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                   <p>{{ description }}</p>
                 }
               </div>
-              @if (!field.required) {
+              @if (control().enabled && !field.required) {
                 <button
                   mat-icon-button
                   aria-label="Delete property from step"
@@ -232,15 +232,17 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 }
               </div>
               <div class="group-field__actions">
-                <button
-                  mat-icon-button
-                  aria-label="Add property to step"
-                  type="button"
-                  (click)="stepForm().addArrayItem(asFormArray(fieldControl), field)"
-                >
-                  <mat-icon>library_add</mat-icon>
-                </button>
-                @if (!field.required) {
+                @if (asFormArray(fieldControl).enabled) {
+                  <button
+                    mat-icon-button
+                    aria-label="Add property to step"
+                    type="button"
+                    (click)="stepForm().addArrayItem(asFormArray(fieldControl), field)"
+                  >
+                    <mat-icon>library_add</mat-icon>
+                  </button>
+                }
+                @if (control().enabled && !field.required) {
                   <button
                     mat-icon-button
                     aria-label="Delete property from step"
@@ -262,14 +264,16 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                 <section class="array-item">
                   <div class="array-item__header">
                     <h5>{{ labelFor(field) }} {{ $index + 1 }}</h5>
-                    <button
-                      mat-icon-button
-                      aria-label="Delete property from step"
-                      type="button"
-                      (click)="stepForm().removeArrayItem(asFormArray(fieldControl), $index)"
-                    >
-                      <mat-icon>delete</mat-icon>
-                    </button>
+                    @if (asFormArray(fieldControl).enabled) {
+                      <button
+                        mat-icon-button
+                        aria-label="Delete property from step"
+                        type="button"
+                        (click)="stepForm().removeArrayItem(asFormArray(fieldControl), $index)"
+                      >
+                        <mat-icon>delete</mat-icon>
+                      </button>
+                    }
                   </div>
                   <builder-step-fields
                     [variantId]="variantId()"
@@ -290,14 +294,16 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                       [type]="field.element.kind === 'number' ? 'number' : 'text'"
                     />
                   </mat-form-field>
-                  <button
-                    mat-icon-button
-                    aria-label="Delete property from step"
-                    type="button"
-                    (click)="stepForm().removeArrayItem(asFormArray(fieldControl), $index)"
-                  >
-                    <mat-icon>delete</mat-icon>
-                  </button>
+                  @if (asFormArray(fieldControl).enabled) {
+                    <button
+                      mat-icon-button
+                      aria-label="Delete property from step"
+                      type="button"
+                      (click)="stepForm().removeArrayItem(asFormArray(fieldControl), $index)"
+                    >
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  }
                 </div>
               }
             }
@@ -312,7 +318,7 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                   <p>{{ description }}</p>
                 }
               </div>
-              @if (!field.required) {
+              @if (control().enabled && !field.required) {
                 <button
                   mat-icon-button
                   aria-label="Delete property from step"
@@ -335,26 +341,30 @@ type RecordField = Extract<BuilderFieldSpec, { kind: 'record' }>;
                     [type]="field.value.kind === 'number' ? 'number' : 'text'"
                   />
                 </mat-form-field>
-                <button
-                  mat-icon-button
-                  aria-label="Delete property from step"
-                  type="button"
-                  (click)="stepForm().removeRecordEntry(asFormRecord(fieldControl), entry.key)"
-                >
-                  <mat-icon>delete</mat-icon>
-                </button>
+                @if (asFormRecord(fieldControl).enabled) {
+                  <button
+                    mat-icon-button
+                    aria-label="Delete property from step"
+                    type="button"
+                    (click)="stepForm().removeRecordEntry(asFormRecord(fieldControl), entry.key)"
+                  >
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                }
               </div>
             }
 
-            <div class="field-row field-row--record-add">
-              <mat-form-field class="field-row__control">
-                <mat-label>New Key</mat-label>
-                <input #recordKey matInput type="text" />
-              </mat-form-field>
-              <button mat-button type="button" (click)="addRecordEntry(field, asFormRecord(fieldControl), recordKey)">
-                Add Entry
-              </button>
-            </div>
+            @if (asFormRecord(fieldControl).enabled) {
+              <div class="field-row field-row--record-add">
+                <mat-form-field class="field-row__control">
+                  <mat-label>New Key</mat-label>
+                  <input #recordKey matInput type="text" />
+                </mat-form-field>
+                <button mat-button type="button" (click)="addRecordEntry(field, asFormRecord(fieldControl), recordKey)">
+                  Add Entry
+                </button>
+              </div>
+            }
           </section>
         }
       }

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -169,7 +169,7 @@ export class BuilderComponent implements OnInit {
       return 'analyze';
     }
 
-    return this.auditResultStatus() ? 'fork' : 'none';
+    return this.auditDetails() ? 'fork' : 'none';
   });
   readonly collapseSteps = computed(() => this.requestId() !== null);
   readonly inlineError = computed(() => {

--- a/libs/audit/portal/builder/src/lib/step-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.spec.ts
@@ -1,4 +1,4 @@
-import { FormArray, FormGroup } from '@angular/forms';
+import { FormArray, FormGroup, FormRecord } from '@angular/forms';
 import { AUDIT_CUSTOM_STEP_TYPE, type BuilderFieldSpec } from '@app-speed/audit/domain';
 import { describe, expect, it } from 'vitest';
 import { BuilderStepFormGroup, findStepSpec } from './step-form';
@@ -96,6 +96,54 @@ describe('BuilderStepFormGroup', () => {
 
     expect(segmentsControl?.hasError('minlength')).toBe(true);
   });
+
+  it('does not add or remove optional fields when the target group is disabled', () => {
+    const form = createForm(AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE);
+    const sameSiteField = findField(form.spec.fields, 'sameSite');
+
+    form.disable();
+    form.addOptionalField(form, sameSiteField);
+
+    expect(form.get('sameSite')).toBeNull();
+
+    form.enable();
+    form.addOptionalField(form, sameSiteField);
+    form.disable();
+    form.removeOptionalField(form, sameSiteField);
+
+    expect(form.get('sameSite')).not.toBeNull();
+  });
+
+  it('does not add or remove array items when the target array is disabled', () => {
+    const form = createForm('click');
+    const selectorsField = expectArrayField(findField(form.spec.fields, 'selectors'));
+    const selectorsControl = form.get('selectors') as FormArray<FormGroup>;
+
+    form.addArrayItem(selectorsControl, selectorsField);
+    selectorsControl.disable();
+    form.addArrayItem(selectorsControl, selectorsField);
+    form.removeArrayItem(selectorsControl, 0);
+
+    expect(selectorsControl.length).toBe(1);
+  });
+
+  it('does not add or remove record entries when the target record is disabled', () => {
+    const form = createForm('waitForElement');
+    const propertiesField = expectRecordField(findField(form.spec.fields, 'properties'));
+
+    form.addOptionalField(form, propertiesField);
+    const propertiesControl = form.get('properties') as FormRecord;
+
+    expect(form.addRecordEntry(propertiesControl, propertiesField, 'disabled', 'false')).toBe(true);
+
+    propertiesControl.disable();
+
+    expect(form.addRecordEntry(propertiesControl, propertiesField, 'hidden', 'true')).toBe(false);
+
+    form.removeRecordEntry(propertiesControl, 'disabled');
+
+    expect(propertiesControl.getRawValue()).toEqual({ disabled: 'false' });
+  });
 });
 
 function createForm(variantId: string, value?: Record<string, unknown>): BuilderStepFormGroup {
@@ -129,6 +177,16 @@ function expectGroupField(field: BuilderFieldSpec): Extract<BuilderFieldSpec, { 
 
   if (field.kind !== 'group') {
     throw new Error(`Expected group field, got ${field.kind}`);
+  }
+
+  return field;
+}
+
+function expectRecordField(field: BuilderFieldSpec): Extract<BuilderFieldSpec, { kind: 'record' }> {
+  expect(field.kind).toBe('record');
+
+  if (field.kind !== 'record') {
+    throw new Error(`Expected record field, got ${field.kind}`);
   }
 
   return field;

--- a/libs/audit/portal/builder/src/lib/step-form.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.ts
@@ -45,11 +45,19 @@ export class BuilderStepFormGroup extends FormGroup {
   }
 
   addOptionalField(control: FormGroup, field: BuilderFieldSpec): void {
+    if (control.disabled) {
+      return;
+    }
+
     control.addControl(fieldControlName(field), createControlForField(field));
     control.updateValueAndValidity();
   }
 
   removeOptionalField(control: FormGroup, field: BuilderFieldSpec): void {
+    if (control.disabled) {
+      return;
+    }
+
     control.removeControl(fieldControlName(field));
     control.updateValueAndValidity();
   }
@@ -59,11 +67,19 @@ export class BuilderStepFormGroup extends FormGroup {
     field: Extract<BuilderFieldSpec, { kind: 'array' }>,
     value?: unknown,
   ): void {
+    if (control.disabled) {
+      return;
+    }
+
     control.push(createControlForField(field.element, value));
     control.updateValueAndValidity();
   }
 
   removeArrayItem(control: FormArray<AbstractControl>, index: number): void {
+    if (control.disabled) {
+      return;
+    }
+
     control.removeAt(index);
     control.updateValueAndValidity();
   }
@@ -74,6 +90,10 @@ export class BuilderStepFormGroup extends FormGroup {
     key: string,
     value?: unknown,
   ): boolean {
+    if (control.disabled) {
+      return false;
+    }
+
     const normalizedKey = key.trim();
 
     if (normalizedKey.length === 0 || hasControl(control, normalizedKey)) {
@@ -87,6 +107,10 @@ export class BuilderStepFormGroup extends FormGroup {
   }
 
   removeRecordEntry(control: FormRecord<AbstractControl>, key: string): void {
+    if (control.disabled) {
+      return;
+    }
+
     control.removeControl(key);
     control.updateValueAndValidity();
   }


### PR DESCRIPTION
## Summary
- make persisted user-flow result builders explicitly read-only with a visible locked-state banner
- hide nested mutation affordances and show Fork for loaded persisted runs
- guard structural mutation helpers against disabled groups, arrays, records, and root step forms

## Validation
- pnpm exec nx test audit-portal-builder
- pnpm run lint:affected
- pnpm run test:affected
- pnpm run build:affected

Closes #168