### PR TITLE
fix(audit-viewer): show loading indicator for results

### DIFF
--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.spec.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.spec.ts
@@ -1,0 +1,73 @@
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import type { FlowResult } from 'lighthouse';
+import { AuditViewerContainer } from './audit-viewer.container';
+
+@Component({
+  standalone: true,
+  imports: [AuditViewerContainer],
+  template: ` <viewer-container [auditId]="auditId" /> `,
+})
+class TestHostComponent {
+  auditId = 'run-123';
+}
+
+const successfulResult = {
+  steps: [
+    {
+      name: 'Home page',
+      lhr: {
+        gatherMode: 'navigation',
+        fullPageScreenshot: null,
+        categoryGroups: {},
+        categories: {
+          performance: {
+            title: 'Performance',
+            score: 0.92,
+            auditRefs: [],
+          },
+        },
+        audits: {},
+      },
+    },
+  ],
+} as unknown as FlowResult;
+
+describe('AuditViewerContainer', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let http: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [provideNoopAnimations(), provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('shows a loading indicator until the audit result is rendered', async () => {
+    await fixture.whenStable();
+
+    const request = http.expectOne('/api/audit/run-123/result');
+    expect(request.request.method).toBe('GET');
+    expect(fixture.nativeElement.textContent).toContain('Loading audit results...');
+    expect(fixture.nativeElement.querySelector('[data-testid="audit-results-loading"]')?.getAttribute('role')).toBe(
+      'status',
+    );
+
+    request.flush({ status: 'SUCCESS', result: successfulResult });
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="audit-results-loading"]')).toBeNull();
+    expect(fixture.nativeElement.textContent).toContain('Home page');
+  });
+});

--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
@@ -1,23 +1,43 @@
 import { ChangeDetectionStrategy, Component, computed, inject, input, model } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { filter, map, Observable, switchMap } from 'rxjs';
-import { FlowResult } from 'lighthouse';
+import { filter, map, Observable, shareReplay, switchMap } from 'rxjs';
+import type { FlowResult } from 'lighthouse';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ViewerStepDetailComponent } from '../steps/viewer-step-details.component';
 import { calculateCategoryFraction, shouldDisplayAsFraction } from '../lighthouse-report-utils';
 import { AuditSummary, AuditSummaryComponent } from '../summary/audit-summary.component';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'viewer-container',
   template: `
-    @if (auditSummary(); as summary) {
-      <ui-audit-summary [(activeIndex)]="activeIndex" [auditSummary]="summary" />
-    }
-    @if (auditStep(); as step) {
-      <viewer-step-detail [stepDetails]="step" />
+    @if (loading()) {
+      <div class="loading-state" data-testid="audit-results-loading" role="status" aria-live="polite">
+        <mat-spinner diameter="32" />
+        <span>Loading audit results...</span>
+      </div>
+    } @else {
+      @if (auditSummary(); as summary) {
+        <ui-audit-summary [(activeIndex)]="activeIndex" [auditSummary]="summary" />
+      }
+      @if (auditStep(); as step) {
+        <viewer-step-detail [stepDetails]="step" />
+      }
     }
   `,
-  imports: [AuditSummaryComponent, ViewerStepDetailComponent],
+  styles: `
+    :host {
+      display: block;
+    }
+
+    .loading-state {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      margin: 24px 16px;
+    }
+  `,
+  imports: [AuditSummaryComponent, ViewerStepDetailComponent, MatProgressSpinner],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AuditViewerContainer {
@@ -32,36 +52,38 @@ export class AuditViewerContainer {
         map((response) => response.result),
       );
     }),
-  );
-
-  auditSummary = toSignal<AuditSummary>(
-    this.flowResult$.pipe(
-      filter(Boolean),
-      map(({ steps }) => {
-        return steps.map(({ lhr: { fullPageScreenshot, categories, gatherMode, audits }, name }) => ({
-          screenShot: fullPageScreenshot?.screenshot.data || '',
-          title: name,
-          subTitle: gatherMode,
-          shouldDisplayAsFraction: shouldDisplayAsFraction(gatherMode),
-          categoryScores: Object.values(categories).map((category) => {
-            const extendedCategory = {
-              ...category,
-              auditRefs: category.auditRefs.map((ref) => {
-                return { ...ref, result: audits[ref.id] };
-              }),
-            };
-            return {
-              name: category.title,
-              asFraction: calculateCategoryFraction(extendedCategory),
-              score: parseInt(((category.score || 0) * 100).toFixed(0), 10),
-            };
-          }),
-        }));
-      }),
-    ),
+    shareReplay({ bufferSize: 1, refCount: true }),
   );
 
   results = toSignal(this.flowResult$.pipe(filter(Boolean)));
+  loading = computed(() => !this.results());
+  auditSummary = computed<AuditSummary | undefined>(() => {
+    const results = this.results();
+    if (!results) {
+      return undefined;
+    }
+
+    return results.steps.map(({ lhr: { fullPageScreenshot, categories, gatherMode, audits }, name }) => ({
+      screenShot: fullPageScreenshot?.screenshot.data || '',
+      title: name,
+      subTitle: gatherMode,
+      shouldDisplayAsFraction: shouldDisplayAsFraction(gatherMode),
+      categoryScores: Object.values(categories).map((category) => {
+        const extendedCategory = {
+          ...category,
+          auditRefs: category.auditRefs.map((ref) => {
+            return { ...ref, result: audits[ref.id] };
+          }),
+        };
+        return {
+          name: category.title,
+          asFraction: calculateCategoryFraction(extendedCategory),
+          score: parseInt(((category.score || 0) * 100).toFixed(0), 10),
+        };
+      }),
+    }));
+  });
+
   auditStep = computed(() => {
     const results = this.results();
     const activeStep = this.activeIndex();

--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
@@ -31,10 +31,13 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
     }
 
     .loading-state {
-      display: inline-flex;
+      display: flex;
       align-items: center;
+      justify-content: center;
       gap: 10px;
-      margin: 24px 16px;
+      min-height: 320px;
+      margin: 24px 0;
+      text-align: center;
     }
   `,
   imports: [AuditSummaryComponent, ViewerStepDetailComponent, MatProgressSpinner],


### PR DESCRIPTION
## Summary

- Add an accessible loading state while the audit viewer waits for the large result payload to render.
- Share the result request and derive summary/detail rendering from the loaded result signal.
- Add focused coverage for the loading-to-rendered transition.

## Testing

- `pnpm exec nx test audit-portal-viewer`
- `pnpm exec nx lint audit-portal-viewer`
- `pnpm exec nx build audit-portal-viewer`

Closes #167