### PR TITLE
Sync viewer step navigation with URL fragments

### DIFF
--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.spec.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.spec.ts
@@ -3,7 +3,10 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, Router } from '@angular/router';
+import { By } from '@angular/platform-browser';
 import type { FlowResult } from 'lighthouse';
+import { BehaviorSubject } from 'rxjs';
 import { AuditViewerContainer } from './audit-viewer.container';
 
 @Component({
@@ -39,11 +42,28 @@ const successfulResult = {
 describe('AuditViewerContainer', () => {
   let fixture: ComponentFixture<TestHostComponent>;
   let http: HttpTestingController;
+  let fragment$: BehaviorSubject<string | null>;
+  let navigate: ReturnType<typeof vi.fn>;
 
   beforeEach(async () => {
+    fragment$ = new BehaviorSubject<string | null>(null);
+    navigate = vi.fn();
+
     await TestBed.configureTestingModule({
       imports: [TestHostComponent],
-      providers: [provideNoopAnimations(), provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideNoopAnimations(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: ActivatedRoute,
+          useValue: { fragment: fragment$.asObservable() },
+        },
+        {
+          provide: Router,
+          useValue: { navigate },
+        },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestHostComponent);
@@ -69,5 +89,59 @@ describe('AuditViewerContainer', () => {
 
     expect(fixture.nativeElement.querySelector('[data-testid="audit-results-loading"]')).toBeNull();
     expect(fixture.nativeElement.textContent).toContain('Home page');
+  });
+
+  it('selects the step encoded in the URL fragment once results load', async () => {
+    fragment$.next('step-2');
+    await fixture.whenStable();
+
+    const request = http.expectOne('/api/audit/run-123/result');
+    request.flush({
+      status: 'SUCCESS',
+      result: {
+        steps: [
+          successfulResult.steps[0],
+          {
+            ...successfulResult.steps[0],
+            name: 'Checkout page',
+          },
+        ],
+      },
+    });
+    await fixture.whenStable();
+
+    const container = fixture.debugElement.query(By.directive(AuditViewerContainer)).componentInstance as AuditViewerContainer;
+    expect(container.activeIndex()).toBe(1);
+  });
+
+  it('writes the visible step to the URL fragment', async () => {
+    await fixture.whenStable();
+
+    const request = http.expectOne('/api/audit/run-123/result');
+    request.flush({
+      status: 'SUCCESS',
+      result: {
+        steps: [
+          successfulResult.steps[0],
+          {
+            ...successfulResult.steps[0],
+            name: 'Checkout page',
+          },
+        ],
+      },
+    });
+    await fixture.whenStable();
+
+    const container = fixture.debugElement.query(By.directive(AuditViewerContainer)).componentInstance as AuditViewerContainer;
+    container.activeIndex.set(1);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(navigate).toHaveBeenLastCalledWith([], {
+      relativeTo: TestBed.inject(ActivatedRoute),
+      fragment: 'step-2',
+      queryParamsHandling: 'preserve',
+      replaceUrl: true,
+    });
   });
 });

--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
@@ -1,12 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, inject, input, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, effect, inject, input, model } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { filter, map, Observable, shareReplay, switchMap } from 'rxjs';
+import { combineLatest, distinctUntilChanged, filter, map, Observable, shareReplay, switchMap } from 'rxjs';
 import type { FlowResult } from 'lighthouse';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ViewerStepDetailComponent } from '../steps/viewer-step-details.component';
 import { calculateCategoryFraction, shouldDisplayAsFraction } from '../lighthouse-report-utils';
 import { AuditSummary, AuditSummaryComponent } from '../summary/audit-summary.component';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { ActivatedRoute, Router } from '@angular/router';
 
 @Component({
   selector: 'viewer-container',
@@ -47,6 +48,9 @@ export class AuditViewerContainer {
   auditId = input.required<string>();
   activeIndex = model<number>(0);
   readonly #api = inject(HttpClient);
+  readonly #destroyRef = inject(DestroyRef);
+  readonly #route = inject(ActivatedRoute);
+  readonly #router = inject(Router);
 
   flowResult$: Observable<FlowResult> = toObservable(this.auditId).pipe(
     switchMap((auditId) => {
@@ -95,4 +99,43 @@ export class AuditViewerContainer {
     }
     return results.steps[activeStep];
   });
+
+  constructor() {
+    combineLatest([this.#route.fragment, this.flowResult$])
+      .pipe(
+        map(([fragment, results]) => this.fragmentToStepIndex(fragment, results.steps.length) ?? 0),
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.#destroyRef),
+      )
+      .subscribe((index) => this.activeIndex.set(index));
+
+    effect(() => {
+      const results = this.results();
+      const index = this.activeIndex();
+      if (!results || !results.steps[index]) {
+        return;
+      }
+
+      void this.#router.navigate([], {
+        relativeTo: this.#route,
+        fragment: this.stepIndexToFragment(index),
+        queryParamsHandling: 'preserve',
+        replaceUrl: true,
+      });
+    });
+  }
+
+  private fragmentToStepIndex(fragment: string | null, stepCount: number): number | null {
+    const match = fragment?.match(/^step-(\d+)$/);
+    if (!match) {
+      return null;
+    }
+
+    const index = Number(match[1]) - 1;
+    return Number.isInteger(index) && index >= 0 && index < stepCount ? index : null;
+  }
+
+  private stepIndexToFragment(index: number): string {
+    return `step-${index + 1}`;
+  }
 }

--- a/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.spec.ts
+++ b/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.spec.ts
@@ -1,0 +1,23 @@
+import { BreakpointObserver } from '@angular/cdk/layout';
+import { TestBed } from '@angular/core/testing';
+
+import { AuditSummaryComponent } from './audit-summary.component';
+
+describe('AuditSummaryComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: { isMatched: vi.fn(() => false) },
+        },
+      ],
+    }).compileComponents();
+  });
+
+  it('lets Swiper move clicked step snapshots into view', () => {
+    const component = TestBed.runInInjectionContext(() => new AuditSummaryComponent());
+
+    expect(component.swiperConfig().slideToClickedSlide).toBe(true);
+  });
+});

--- a/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.ts
+++ b/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, input, model } from '@angular/core';
+import { Component, computed, inject, input, model } from '@angular/core';
 import { SwiperComponent } from './swiper.component';
 import { FractionalResultChipComponent } from './fractional-result-chip.component';
 import { SwiperOptions } from 'swiper/types';
@@ -26,7 +26,7 @@ export type AuditSummary = {
   selector: 'ui-audit-summary',
   imports: [SwiperComponent, RadialChartComponent, FractionalResultChipComponent],
   template: `
-    <ui-swiper class="swiper" [swiperOptions]="swiperConfig">
+    <ui-swiper class="swiper" [swiperOptions]="swiperConfig()">
       @for (step of auditSummary(); track step) {
         <div class="swiper-slide">
           <div style="display: block; position: relative">
@@ -199,12 +199,13 @@ export class AuditSummaryComponent {
   activeIndex = model<number>(0);
   #breakpointObserver = inject(BreakpointObserver);
   isMobile = this.#breakpointObserver.isMatched([Breakpoints.Small, Breakpoints.XSmall]);
-  swiperConfig: SwiperOptions = {
+  swiperConfig = computed<SwiperOptions>(() => ({
     centeredSlides: true,
+    initialSlide: this.activeIndex(),
+    slideToClickedSlide: true,
     slidesPerView: this.isMobile ? 1 : 3,
     on: {
-      init: () => this.activeIndex.set(0),
       activeIndexChange: (swiper) => this.activeIndex.set(swiper.activeIndex),
     },
-  };
+  }));
 }


### PR DESCRIPTION
## Summary
- Enable clicked step snapshots to move into view using Swiper's built-in clicked-slide navigation.
- Encode the active viewer step as `#step-N` and restore that step from the URL fragment after results load.
- Preserve deep-linked active steps when the summary carousel initializes.

## Testing
- `pnpm exec nx test audit-portal-viewer`
- `pnpm exec nx lint audit-portal-viewer`