### PR TITLE
fix(audit-builder): guard duplicate audit submits

### DIFF
--- a/libs/audit/portal/builder/src/lib/audit.routes.spec.ts
+++ b/libs/audit/portal/builder/src/lib/audit.routes.spec.ts
@@ -101,6 +101,50 @@ describe('auditBuilderRoutes', () => {
     http.verify();
   });
 
+  it('does not schedule an audit when the loaded result form submits with Fork as the primary action', async () => {
+    await configureRouteTestingModule();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/user-flow/results/run-123', BuilderComponent);
+
+    const http = TestBed.inject(HttpTestingController);
+    const request = http.expectOne('/api/audit/runs/run-123/details');
+    request.flush({
+      auditId: 'run-123',
+      audit: DEFAULT_AUDIT_DETAILS,
+      status: 'SCHEDULED',
+      resultStatus: null,
+      queuePosition: 2,
+      createdAt: '2026-03-03T10:00:00.000Z',
+      startedAt: null,
+      completedAt: null,
+      durationMs: null,
+    });
+    await harness.fixture.whenStable();
+
+    const root = harness.fixture.nativeElement as HTMLElement;
+    root.querySelector('form')?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    harness.fixture.detectChanges();
+
+    expect(scheduleAudit).not.toHaveBeenCalled();
+    http.verify();
+  });
+
+  it('ignores repeated submit attempts while scheduling is already in flight', async () => {
+    await configureRouteTestingModule();
+    const submitResponse$ = new Subject<{ auditId: string; auditQueuePosition: number }>();
+    scheduleAudit.mockReturnValue(submitResponse$);
+
+    const harness = await RouterTestingHarness.create();
+    const builder = await harness.navigateByUrl('/user-flow', BuilderComponent);
+
+    builder.submitAudit(DEFAULT_AUDIT_DETAILS);
+    builder.submitAudit(DEFAULT_AUDIT_DETAILS);
+
+    expect(scheduleAudit).toHaveBeenCalledTimes(1);
+    submitResponse$.complete();
+  });
+
   it('redirects the bare results route to history', async () => {
     await configureRouteTestingModule();
 

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.component.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.component.spec.ts
@@ -1,0 +1,93 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatIconRegistry } from '@angular/material/icon';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
+import { DEFAULT_AUDIT_DETAILS } from '../audit-details';
+import { AuditBuilderComponent } from './audit-builder.component';
+
+describe('AuditBuilderComponent', () => {
+  let fixture: ComponentFixture<AuditBuilderComponent>;
+
+  const renderBuilder = async ({
+    modifying,
+    primaryAction,
+    submittingRequest = false,
+  }: {
+    modifying: boolean;
+    primaryAction: 'analyze' | 'fork' | 'none';
+    submittingRequest?: boolean;
+  }) => {
+    await TestBed.configureTestingModule({
+      imports: [AuditBuilderComponent],
+      providers: [
+        provideNoopAnimations(),
+        {
+          provide: MatIconRegistry,
+          useValue: {
+            getNamedSvgIcon: () => of(document.createElementNS('http://www.w3.org/2000/svg', 'svg')),
+            getDefaultFontSetClass: () => ['material-icons'],
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AuditBuilderComponent);
+    fixture.componentRef.setInput('initialAudit', { ...DEFAULT_AUDIT_DETAILS, title: 'Checkout audit' });
+    fixture.componentRef.setInput('modifying', modifying);
+    fixture.componentRef.setInput('primaryAction', primaryAction);
+    fixture.componentRef.setInput('submittingRequest', submittingRequest);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    return fixture;
+  };
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('does not emit a submit when the primary action is Fork', async () => {
+    const submitAudit = vi.fn();
+    const builderFixture = await renderBuilder({ modifying: false, primaryAction: 'fork' });
+    builderFixture.componentInstance.submitAudit.subscribe(submitAudit);
+
+    submitForm(builderFixture);
+
+    expect(submitAudit).not.toHaveBeenCalled();
+  });
+
+  it('does not emit a submit while an audit request is already in flight', async () => {
+    const submitAudit = vi.fn();
+    const builderFixture = await renderBuilder({
+      modifying: true,
+      primaryAction: 'analyze',
+      submittingRequest: true,
+    });
+    builderFixture.componentInstance.submitAudit.subscribe(submitAudit);
+
+    submitForm(builderFixture);
+
+    expect(submitAudit).not.toHaveBeenCalled();
+  });
+
+  it('does not submit after a required field becomes invalid', async () => {
+    const submitAudit = vi.fn();
+    const builderFixture = await renderBuilder({ modifying: true, primaryAction: 'analyze' });
+    builderFixture.componentInstance.submitAudit.subscribe(submitAudit);
+
+    const titleInput = builderFixture.nativeElement.querySelector('input[name="audit title"]') as HTMLInputElement;
+    titleInput.value = '';
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }));
+    builderFixture.detectChanges();
+
+    submitForm(builderFixture);
+
+    expect(submitAudit).not.toHaveBeenCalled();
+  });
+});
+
+function submitForm(fixture: ComponentFixture<AuditBuilderComponent>): void {
+  const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+  form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+  fixture.detectChanges();
+}

--- a/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder.component.ts
@@ -32,7 +32,7 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
 @Component({
   selector: 'ui-audit-builder',
   template: `
-    <form class="grid-container" [formGroup]="formGroup" (ngSubmit)="submitAudit.emit(auditValue())">
+    <form class="grid-container" [formGroup]="formGroup" (ngSubmit)="submitCurrentAudit()">
       <mat-card class="audit-card" [class.audit-card--readonly]="!modifying()" data-testid="audit-builder-card">
         <mat-card-content>
           <div class="row">
@@ -45,7 +45,7 @@ import { ToTitleCasePipe } from '@app-speed/audit/portal/ui';
               <button
                 class="submit-btn"
                 mat-fab
-                [disabled]="formGroup.disabled || formGroup.invalid"
+                [disabled]="!canSubmitAudit()"
                 [extended]="true"
                 type="submit"
               >
@@ -142,6 +142,7 @@ export class AuditBuilderComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
   public readonly modifying = input.required<boolean>();
   public readonly primaryAction = input<'analyze' | 'fork' | 'none'>('analyze');
+  public readonly submittingRequest = input(false);
   public readonly collapseSteps = input(false);
   protected readonly stepExpanded = computed(() => !this.collapseSteps());
 
@@ -167,6 +168,24 @@ export class AuditBuilderComponent implements OnInit {
 
   protected auditValue(): AuditDetails {
     return this.formGroup.getRawValue() as unknown as AuditDetails;
+  }
+
+  protected submitCurrentAudit(): void {
+    if (!this.canSubmitAudit()) {
+      return;
+    }
+
+    this.submitAudit.emit(this.auditValue());
+  }
+
+  protected canSubmitAudit(): boolean {
+    return (
+      this.primaryAction() === 'analyze' &&
+      this.modifying() &&
+      !this.submittingRequest() &&
+      this.formGroup?.enabled === true &&
+      this.formGroup.valid
+    );
   }
 
   private syncFormMode(modifying: boolean): void {

--- a/libs/audit/portal/builder/src/lib/feature/builder.component.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.component.ts
@@ -26,6 +26,7 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
         (modified)="updateAuditDetails($event)"
         [initialAudit]="auditDetails"
         [primaryAction]="primaryAction()"
+        [submittingRequest]="submittingRequest()"
         [collapseSteps]="collapseSteps()"
         (submitAudit)="submitAudit($event)"
         (forked)="forkCurrentAudit(auditDetails)"
@@ -150,6 +151,8 @@ export class BuilderComponent implements OnInit {
   public readonly auditDetails$ = this.store.select(auditBuilderFeature.selectAudit);
   public readonly modifying$ = this.store.select(auditBuilderFeature.selectModifying);
   public readonly modifying = toSignal(this.modifying$, { initialValue: true });
+  private readonly submittingRequest$ = this.store.select(auditBuilderFeature.selectSubmittingRequest);
+  readonly submittingRequest = toSignal(this.submittingRequest$, { initialValue: false });
   private readonly loadingDialog$ = this.store.select(auditBuilderFeature.selectLoadingDialog);
   readonly loadingDialog = toSignal<StatusDialogModel | null>(this.loadingDialog$, { initialValue: null });
   readonly auditDetails = toSignal(this.auditDetails$, { initialValue: null });
@@ -204,6 +207,10 @@ export class BuilderComponent implements OnInit {
   }
 
   submitAudit(audit: AuditDetails): void {
+    if (this.primaryAction() !== 'analyze' || !this.modifying() || this.submittingRequest()) {
+      return;
+    }
+
     this.store.dispatch(submitAuditRequest({ audit }));
   }
 

--- a/libs/audit/portal/builder/src/lib/feature/builder.effects.ts
+++ b/libs/audit/portal/builder/src/lib/feature/builder.effects.ts
@@ -18,7 +18,7 @@ import {
   submitAuditRequestSuccess,
   updateAuditDetails,
 } from './builder.actions';
-import { EMPTY, catchError, debounceTime, distinctUntilChanged, filter, map, of, switchMap, tap } from 'rxjs';
+import { EMPTY, catchError, debounceTime, distinctUntilChanged, exhaustMap, filter, map, of, switchMap, tap } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
 import { AuditDetails, DEFAULT_AUDIT_DETAILS } from '../audit-details';
 import { HttpClient } from '@angular/common/http';
@@ -109,7 +109,7 @@ const submitAuditRequestEffect = createEffect(
   (actions$ = inject(Actions), api = inject(ApiClient)) =>
     actions$.pipe(
       ofType(submitAuditRequest),
-      switchMap(({ audit }) =>
+      exhaustMap(({ audit }) =>
         api.scheduleAudit(audit).pipe(
           map((response) =>
             submitAuditRequestSuccess({


### PR DESCRIPTION
## Summary

Fixes #170.

- Gate the audit builder form submit so Enter/Go/Done only submits when the visible primary action is Analyze, the builder is editable, the form is valid, and no request is already in flight.
- Add a parent-level dispatch guard using the builder state so stale or repeated submit events do not dispatch scheduling actions.
- Change the scheduling effect to ignore duplicate submit actions while the schedule request is active.
- Add regression coverage for submitting while Fork is the primary action and repeated submit attempts during an in-flight schedule request.

## Root Cause

The root builder form handled ngSubmit unconditionally, so mobile keyboard submit events could schedule an audit even when the UI was showing Fork for a read-only result. Duplicate submit actions also flowed into the scheduling effect, where switchMap could restart the API call rather than ignoring repeats.

## Validation

- `pnpm exec nx test audit-portal-builder`
- `pnpm exec nx build audit-portal-builder`
- `pnpm exec nx lint audit-portal-builder`
- `git diff --check`