### PR TITLE
fix(audit): preserve progress during sse reconnect

### DIFF
--- a/libs/audit/api-runtime/src/lib/audit/builder/Http.ts
+++ b/libs/audit/api-runtime/src/lib/audit/builder/Http.ts
@@ -15,7 +15,8 @@ type AuditSnapshot = {
 type AuditSseEvent =
   | { event: 'position'; data: { auditId: string; position: number } }
   | { event: 'status'; data: { auditId: string; status: AuditSnapshot['status'] } }
-  | { event: 'result'; data: { auditId: string; status: 'SUCCESS' | 'FAILURE' } };
+  | { event: 'result'; data: { auditId: string; status: 'SUCCESS' | 'FAILURE' } }
+  | { event: 'heartbeat'; data: { auditId: string } };
 
 const encoder = new TextEncoder();
 const encodeSse = (event: AuditSseEvent) =>
@@ -116,6 +117,9 @@ export const watchByIdHandler = Effect.fn('api.audit.watchById')((request) =>
         }
         if (next.resultStatus && (!prev || next.resultStatus !== prev.resultStatus)) {
           events.push({ event: 'result', data: { auditId, status: next.resultStatus } });
+        }
+        if (events.length === 0) {
+          events.push({ event: 'heartbeat', data: { auditId } });
         }
         return [next, events];
       }),

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
@@ -84,4 +84,32 @@ describe('AuditProgressService', () => {
     stageSubscription.unsubscribe();
     keySubscription.unsubscribe();
   });
+
+  it('ignores stale fallback result responses after another audit starts', () => {
+    const service = TestBed.inject(AuditProgressService);
+    const http = TestBed.inject(HttpTestingController);
+    const stages: string[] = [];
+    const resultKeys: string[] = [];
+    const stageSubscription = service.stageName$.subscribe((stage) => stages.push(stage));
+    const keySubscription = service.key$.subscribe((key) => resultKeys.push(key));
+
+    service.watchAudit('audit-a');
+    const auditASource = MockEventSource.instances[0];
+    auditASource.dispatchEvent(new MessageEvent('status', { data: JSON.stringify({ status: 'IN_PROGRESS' }) }));
+    auditASource.readyState = MockEventSource.CLOSED;
+    auditASource.dispatchEvent(new Event('error'));
+    const auditAResultRequest = http.expectOne('/api/audit/audit-a/result');
+
+    service.watchAudit('audit-b');
+    const auditBSource = MockEventSource.instances[1];
+    auditBSource.dispatchEvent(new MessageEvent('status', { data: JSON.stringify({ status: 'IN_PROGRESS' }) }));
+    auditAResultRequest.flush({ status: 'SUCCESS', result: {} });
+
+    expect(stages.at(-1)).toBe('running');
+    expect(resultKeys).toEqual([]);
+    expect(auditBSource.closed).toBe(false);
+
+    stageSubscription.unsubscribe();
+    keySubscription.unsubscribe();
+  });
 });

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
@@ -1,5 +1,5 @@
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { AuditProgressService } from './audit-progress.service';
 
@@ -40,6 +40,7 @@ describe('AuditProgressService', () => {
 
   it('keeps the current progress stage when the EventSource reports a reconnectable error', () => {
     const service = TestBed.inject(AuditProgressService);
+    const http = TestBed.inject(HttpTestingController);
     const stages: string[] = [];
     const subscription = service.stageName$.subscribe((stage) => stages.push(stage));
 
@@ -53,7 +54,34 @@ describe('AuditProgressService', () => {
     expect(stages).not.toContain('failed');
     expect(stages.at(-1)).toBe('running');
     expect(source.closed).toBe(false);
+    http.expectNone('/api/audit/audit-123/result');
 
     subscription.unsubscribe();
+  });
+
+  it('surfaces a failed stage when the EventSource closes permanently before a result is available', () => {
+    const service = TestBed.inject(AuditProgressService);
+    const http = TestBed.inject(HttpTestingController);
+    const stages: string[] = [];
+    const resultKeys: string[] = [];
+    const stageSubscription = service.stageName$.subscribe((stage) => stages.push(stage));
+    const keySubscription = service.key$.subscribe((key) => resultKeys.push(key));
+
+    service.watchAudit('audit-123');
+
+    const source = MockEventSource.instances[0];
+    source.dispatchEvent(new MessageEvent('status', { data: JSON.stringify({ status: 'IN_PROGRESS' }) }));
+    source.readyState = MockEventSource.CLOSED;
+    source.dispatchEvent(new Event('error'));
+
+    const request = http.expectOne('/api/audit/audit-123/result');
+    request.flush({ message: 'Result not available.' }, { status: 404, statusText: 'Not Found' });
+
+    expect(stages.at(-1)).toBe('failed');
+    expect(resultKeys).toEqual(['audit-123']);
+    expect(source.closed).toBe(true);
+
+    stageSubscription.unsubscribe();
+    keySubscription.unsubscribe();
   });
 });

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.spec.ts
@@ -1,0 +1,59 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { AuditProgressService } from './audit-progress.service';
+
+class MockEventSource extends EventTarget {
+  static readonly CLOSED = 2;
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+
+  static instances: MockEventSource[] = [];
+
+  readyState = MockEventSource.OPEN;
+  closed = false;
+
+  constructor(readonly url: string) {
+    super();
+    MockEventSource.instances.push(this);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.readyState = MockEventSource.CLOSED;
+  }
+}
+
+describe('AuditProgressService', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource);
+
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps the current progress stage when the EventSource reports a reconnectable error', () => {
+    const service = TestBed.inject(AuditProgressService);
+    const stages: string[] = [];
+    const subscription = service.stageName$.subscribe((stage) => stages.push(stage));
+
+    service.watchAudit('audit-123');
+
+    const source = MockEventSource.instances[0];
+    source.dispatchEvent(new MessageEvent('status', { data: JSON.stringify({ status: 'IN_PROGRESS' }) }));
+    source.readyState = MockEventSource.CONNECTING;
+    source.dispatchEvent(new Event('error'));
+
+    expect(stages).not.toContain('failed');
+    expect(stages.at(-1)).toBe('running');
+    expect(source.closed).toBe(false);
+
+    subscription.unsubscribe();
+  });
+});

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
@@ -37,6 +37,7 @@ export class AuditProgressService {
         this.stage$.next('failed');
         this.resultKey$.next(auditId);
         this.eventSource?.close();
+        this.currentAuditId = null;
       },
     });
   }
@@ -91,8 +92,13 @@ export class AuditProgressService {
     fromEvent<Event>(source, 'error')
       .pipe(takeUntil(this.disconnect$))
       .subscribe(() => {
-        if (source.readyState === EventSource.CLOSED) {
-          this.currentAuditId = null;
+        if (
+          source.readyState === EventSource.CLOSED &&
+          this.currentAuditId === auditId &&
+          this.stage$.value !== 'done' &&
+          this.stage$.value !== 'failed'
+        ) {
+          this.fetchResultAndFinalize(auditId);
         }
       });
   }

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
@@ -32,8 +32,18 @@ export class AuditProgressService {
 
   private fetchResultAndFinalize(auditId: string) {
     this.http.get<AuditResultResponse>(`/api/audit/${auditId}/result`).subscribe({
-      next: (result) => this.finalizeWithStatus(auditId, result.status),
+      next: (result) => {
+        if (this.currentAuditId !== auditId) {
+          return;
+        }
+
+        this.finalizeWithStatus(auditId, result.status);
+      },
       error: () => {
+        if (this.currentAuditId !== auditId) {
+          return;
+        }
+
         this.stage$.next('failed');
         this.resultKey$.next(auditId);
         this.eventSource?.close();

--- a/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
+++ b/libs/audit/portal/builder/src/lib/api/audit-progress.service.ts
@@ -91,10 +91,8 @@ export class AuditProgressService {
     fromEvent<Event>(source, 'error')
       .pipe(takeUntil(this.disconnect$))
       .subscribe(() => {
-        source.close();
-        this.currentAuditId = null;
-        if (this.stage$.value !== 'done') {
-          this.stage$.next('failed');
+        if (source.readyState === EventSource.CLOSED) {
+          this.currentAuditId = null;
         }
       });
   }


### PR DESCRIPTION
## Summary
- keep audit progress UI visible when the SSE listener reports a reconnectable transport error
- emit heartbeat SSE events while an audit is otherwise unchanged so long-running audits do not leave the stream idle
- add a regression test for preserving the running stage across EventSource errors

## Root Cause
The frontend treated `EventSource.onerror` as an audit progress failure by moving the local audit stage to `failed`. That did not dispatch `auditResultFailure`, so no failure UI appeared, but the reducer stopped rendering the loading card because it only renders for `scheduling`, `scheduled`, and `running`.

The backend SSE stream also only wrote bytes when position, status, or result status changed. A long `IN_PROGRESS` audit could leave the stream idle until completion, making transport/proxy disconnects more likely.

Closes #177

## Validation
- `pnpm exec nx test audit-portal-builder`
- `pnpm exec nx lint audit-portal-builder`
- `pnpm exec nx build audit-portal-builder`
- `pnpm exec nx lint audit-api-runtime`
- `pnpm exec nx build audit-api-runtime`
