### PR TITLE
fix(audit): preserve screenshot preview aspect ratio

### DIFF
--- a/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
+++ b/libs/audit/portal/viewer/src/lib/page/audit-viewer.container.ts
@@ -5,7 +5,7 @@ import type { FlowResult } from 'lighthouse';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ViewerStepDetailComponent } from '../steps/viewer-step-details.component';
 import { calculateCategoryFraction, shouldDisplayAsFraction } from '../lighthouse-report-utils';
-import { AuditSummary, AuditSummaryComponent } from '../summary/audit-summary.component';
+import { AuditSummary, AuditSummaryComponent, fitScreenshotPreview } from '../summary/audit-summary.component';
 import { MatProgressSpinner } from '@angular/material/progress-spinner';
 import { ActivatedRoute, Router } from '@angular/router';
 
@@ -70,25 +70,29 @@ export class AuditViewerContainer {
       return undefined;
     }
 
-    return results.steps.map(({ lhr: { fullPageScreenshot, categories, gatherMode, audits }, name }) => ({
-      screenShot: fullPageScreenshot?.screenshot.data || '',
-      title: name,
-      subTitle: gatherMode,
-      shouldDisplayAsFraction: shouldDisplayAsFraction(gatherMode),
-      categoryScores: Object.values(categories).map((category) => {
-        const extendedCategory = {
-          ...category,
-          auditRefs: category.auditRefs.map((ref) => {
-            return { ...ref, result: audits[ref.id] };
-          }),
-        };
-        return {
-          name: category.title,
-          asFraction: calculateCategoryFraction(extendedCategory),
-          score: parseInt(((category.score || 0) * 100).toFixed(0), 10),
-        };
-      }),
-    }));
+    return results.steps.map(({ lhr: { fullPageScreenshot, categories, gatherMode, audits }, name }) => {
+      const screenshot = fullPageScreenshot?.screenshot;
+      return {
+        screenShot: screenshot?.data || '',
+        screenShotSize: fitScreenshotPreview(screenshot?.width ?? 0, screenshot?.height ?? 0),
+        title: name,
+        subTitle: gatherMode,
+        shouldDisplayAsFraction: shouldDisplayAsFraction(gatherMode),
+        categoryScores: Object.values(categories).map((category) => {
+          const extendedCategory = {
+            ...category,
+            auditRefs: category.auditRefs.map((ref) => {
+              return { ...ref, result: audits[ref.id] };
+            }),
+          };
+          return {
+            name: category.title,
+            asFraction: calculateCategoryFraction(extendedCategory),
+            score: parseInt(((category.score || 0) * 100).toFixed(0), 10),
+          };
+        }),
+      };
+    });
   });
 
   auditStep = computed(() => {

--- a/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.spec.ts
+++ b/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.spec.ts
@@ -1,7 +1,7 @@
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { TestBed } from '@angular/core/testing';
 
-import { AuditSummaryComponent } from './audit-summary.component';
+import { AuditSummaryComponent, fitScreenshotPreview } from './audit-summary.component';
 
 describe('AuditSummaryComponent', () => {
   beforeEach(async () => {
@@ -19,5 +19,10 @@ describe('AuditSummaryComponent', () => {
     const component = TestBed.runInInjectionContext(() => new AuditSummaryComponent());
 
     expect(component.swiperConfig().slideToClickedSlide).toBe(true);
+  });
+
+  it('preserves desktop and mobile screenshot aspect ratios in the preview', () => {
+    expect(fitScreenshotPreview(1920, 1080)).toEqual({ width: 250, height: 140.625 });
+    expect(fitScreenshotPreview(360, 720)).toEqual({ width: 125, height: 250 });
   });
 });

--- a/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.ts
+++ b/libs/audit/portal/viewer/src/lib/summary/audit-summary.component.ts
@@ -7,6 +7,10 @@ import { RadialChartComponent } from './radial-chart.component';
 
 export type AuditSummary = {
   screenShot: string;
+  screenShotSize: {
+    width: number;
+    height: number;
+  };
   title: string;
   subTitle: string;
   shouldDisplayAsFraction: boolean;
@@ -21,6 +25,18 @@ export type AuditSummary = {
     score: number;
   }[];
 }[];
+
+const SCREENSHOT_PREVIEW_MAX_SIZE = 250;
+
+export function fitScreenshotPreview(width: number, height: number): { width: number; height: number } {
+  if (width <= 0 || height <= 0) {
+    return { width: 0, height: 0 };
+  }
+
+  return width >= height
+    ? { width: SCREENSHOT_PREVIEW_MAX_SIZE, height: (SCREENSHOT_PREVIEW_MAX_SIZE * height) / width }
+    : { width: (SCREENSHOT_PREVIEW_MAX_SIZE * width) / height, height: SCREENSHOT_PREVIEW_MAX_SIZE };
+}
 
 @Component({
   selector: 'ui-audit-summary',
@@ -43,7 +59,13 @@ export type AuditSummary = {
             </div>
             <span>
               <div class="screen-shot-box">
-                <img class="screen-shot" [src]="step.screenShot" alt="" />
+                <img
+                  class="screen-shot"
+                  [src]="step.screenShot"
+                  [style.width.px]="step.screenShotSize.width"
+                  [style.height.px]="step.screenShotSize.height"
+                  alt=""
+                />
               </div>
             </span>
           </div>
@@ -77,8 +99,9 @@ export type AuditSummary = {
       display: flex;
       justify-content: center;
       align-items: center;
-      width: 125px;
+      width: 250px;
       height: 250px;
+      max-width: 100%;
       margin: auto;
     }
 
@@ -86,18 +109,18 @@ export type AuditSummary = {
       border-radius: 8px;
       transition:
         transform 0.2s ease,
-        height 100ms ease,
-        width 100ms ease,
         box-shadow 0.2s ease;
       margin: auto;
       display: block;
-      width: 50%;
-      height: 50%;
+      max-width: 100%;
+      max-height: 100%;
+      position: relative;
+      z-index: 2;
+      transform: scale(0.5);
 
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
       .swiper-slide-active & {
-        height: 100%;
-        width: 100%;
+        transform: scale(1);
         border: groove blue;
         box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
       }

--- a/libs/audit/portal/viewer/src/lib/summary/audit-summary.stories.ts
+++ b/libs/audit/portal/viewer/src/lib/summary/audit-summary.stories.ts
@@ -15,6 +15,7 @@ export const MultiStep: Story = {
     auditSummary: [
       {
         screenShot: DUMMY_IMG,
+        screenShotSize: { width: 250, height: 140.625 },
         title: 'Audit Title',
         subTitle: 'Step',
         shouldDisplayAsFraction: false,
@@ -53,6 +54,7 @@ export const MultiStep: Story = {
       },
       {
         screenShot: DUMMY_IMG,
+        screenShotSize: { width: 125, height: 250 },
         title: 'Audit Title',
         subTitle: 'Step',
         shouldDisplayAsFraction: true,
@@ -91,6 +93,7 @@ export const MultiStep: Story = {
       },
       {
         screenShot: DUMMY_IMG,
+        screenShotSize: { width: 250, height: 140.625 },
         title: 'Audit Title',
         subTitle: 'Step',
         shouldDisplayAsFraction: false,


### PR DESCRIPTION
## Summary

- derive audit summary preview dimensions from Lighthouse screenshot metadata
- preserve desktop and mobile aspect ratios within the existing 250px preview area
- update the Storybook examples and add regression coverage for both orientations

## Root cause

The summary carousel forced every screenshot into a fixed portrait-shaped box using percentage width and height, stretching desktop captures to mobile dimensions.

## Impact

Desktop audit screenshots now render as landscape previews, while mobile screenshots retain their portrait shape. The existing active/inactive carousel scaling remains intact.

## Validation

- `pnpm exec nx test audit-portal-viewer`
- `pnpm exec nx lint audit-portal-viewer`
- `pnpm exec nx build audit-portal-viewer`

The standalone `typecheck` target currently fails before checking sources because the project config enables `inlineSources` without `sourceMap` or `inlineSourceMap`; the Angular package build succeeds.

Closes #181