### PR TITLE
fix(viewer): improve desktop filmstrip

### DIFF
--- a/libs/audit/portal/viewer/src/lib/steps/viewer-film-strip.component.ts
+++ b/libs/audit/portal/viewer/src/lib/steps/viewer-film-strip.component.ts
@@ -7,33 +7,36 @@ import { ScrollContainerComponent } from '@app-speed/ui/scroll-container';
     <ui-scroll-container>
       <div class="film-strip-container">
         @for (item of filmStrip(); track item) {
-          <img class="film-strip-frame" [src]="item.data" height="100px" alt="" />
+          <img class="film-strip-frame" [src]="item.data" alt="" />
         }
       </div>
     </ui-scroll-container>
   `,
   styles: `
     :host {
+      container-type: inline-size;
       display: block;
-      padding: 20px 0 20px 0;
+      padding: 20px 0;
     }
+
     .film-strip-container {
       display: flex;
+      gap: 16px;
+      justify-content: space-between;
       overflow: auto;
       padding: 8px 4px;
     }
 
     .film-strip-frame {
+      flex: 0 0 auto;
+      height: clamp(100px, 15cqi, 160px);
+      width: auto;
       border: groove gray;
       box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
       border-radius: 8px;
       transition:
         transform 0.2s ease,
         box-shadow 0.2s ease;
-
-      &:not(:first-child):not(:last-child) {
-        margin: 0 8px;
-      }
 
       &:hover {
         transform: scale(1.05);


### PR DESCRIPTION
## Summary

- scale filmstrip frames relative to the available container width
- distribute frames evenly across desktop layouts with consistent spacing
- preserve horizontal scrolling and a 100px minimum frame height on narrow layouts

## Root cause

Filmstrip frames used a fixed 100px height and margins only on middle frames. This kept screenshots too small on desktop and left unused space at the end of the row.

## Validation

- `pnpm exec nx lint audit-portal-viewer`
- `pnpm exec nx test audit-portal-viewer`
- `pnpm exec nx build audit-portal-viewer`
- Prettier check

Closes #179