### PR TITLE
feat(audit): add wait for network idle custom step

### DIFF
--- a/libs/audit/domain/src/index.ts
+++ b/libs/audit/domain/src/index.ts
@@ -17,8 +17,10 @@ export {
   AuditClearCacheStepSchema,
   AuditCustomRunnerStepSchema,
   AuditWaitForTimeStepSchema,
+  AuditWaitForNetworkIdleStepSchema,
   ReplayAuditCustomStepSchema,
   WaitForTimeParametersSchema,
+  WaitForNetworkIdleParametersSchema,
 } from './lib/custom-audit-step';
 export {
   isReplayUserflowStepWithFlags,

--- a/libs/audit/domain/src/lib/audit-step.schema.ts
+++ b/libs/audit/domain/src/lib/audit-step.schema.ts
@@ -35,6 +35,7 @@ export const AppAuditCustomStepTypeSchema = Schema.Literal(
   AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE,
   AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE,
   AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+  AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
 );
 
 export const AuditCustomStepTypeSchema = Schema.Union(LighthouseAuditStepTypeSchema, AppAuditCustomStepTypeSchema);

--- a/libs/audit/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/domain/src/lib/audit.schema.spec.ts
@@ -163,6 +163,49 @@ describe('PuppeteerReplayUserflowRunnerSchema', () => {
     });
   });
 
+  it('should decode waitForNetworkIdle custom steps into replay parameters', () => {
+    const createRecording = (step: Record<string, unknown>) => ({
+      title: 'Stub audit title',
+      device: 'mobile',
+      steps: [
+        step,
+        {
+          type: 'customStep',
+          step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
+          name: 'Home Page',
+        },
+      ],
+    });
+
+    expect(
+      Schema.decodeUnknownSync(PuppeteerReplayUserflowRunnerSchema)(
+        createRecording({
+          type: 'customStep',
+          step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+        }),
+      ).steps[0],
+    ).toEqual({
+      type: 'customStep',
+      name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+      parameters: {},
+    });
+    expect(
+      Schema.decodeUnknownSync(PuppeteerReplayUserflowRunnerSchema)(
+        createRecording({
+          type: 'customStep',
+          step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+          idleTime: 750,
+          timeout: 0,
+          concurrency: 2,
+        }),
+      ).steps[0],
+    ).toEqual({
+      type: 'customStep',
+      name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+      parameters: { idleTime: 750, timeout: 0, concurrency: 2 },
+    });
+  });
+
   it('should decode normalized selector paths into replay-compatible selectors', () => {
     const recording = {
       title: 'Stub audit title',
@@ -303,6 +346,50 @@ describe('AuditSchema', () => {
     expect(Schema.is(AuditSchema)(createAudit(61))).toBe(false);
     expect(Schema.is(AuditSchema)(createAudit(1.5))).toBe(false);
   });
+
+  it('should accept zero-configuration and populated waitForNetworkIdle persisted custom steps', () => {
+    const createAudit = (step: Record<string, unknown>) => ({
+      title: 'Stub audit title',
+      device: 'mobile',
+      steps: [step, { type: 'customStep', step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION }],
+    });
+
+    expect(
+      Schema.is(AuditSchema)(createAudit({ type: 'customStep', step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE })),
+    ).toBe(true);
+    expect(
+      Schema.is(AuditSchema)(
+        createAudit({
+          type: 'customStep',
+          step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+          idleTime: 500,
+          timeout: 0,
+          concurrency: 2,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it.each(['idleTime', 'timeout', 'concurrency'])(
+    'should reject negative and fractional waitForNetworkIdle %s values',
+    (property) => {
+      const createAudit = (value: number) => ({
+        title: 'Stub audit title',
+        device: 'mobile',
+        steps: [
+          {
+            type: 'customStep',
+            step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+            [property]: value,
+          },
+          { type: 'customStep', step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION },
+        ],
+      });
+
+      expect(Schema.is(AuditSchema)(createAudit(-1))).toBe(false);
+      expect(Schema.is(AuditSchema)(createAudit(1.5))).toBe(false);
+    },
+  );
 
   it('should reject replay-shaped custom step input', () => {
     expect(

--- a/libs/audit/domain/src/lib/audit.schema.ts
+++ b/libs/audit/domain/src/lib/audit.schema.ts
@@ -5,6 +5,7 @@ import {
   AuditClearCacheStepSchema,
   AuditCustomRunnerStepSchema,
   AuditWaitForTimeStepSchema,
+  AuditWaitForNetworkIdleStepSchema,
 } from './custom-audit-step';
 import { PuppeteerReplayRunnerStepSchema, PuppeteerReplayStepSchema } from './puppeteer-replay/puppeteer-replay-step';
 import { DeviceSchema } from './shared/device-type';
@@ -15,6 +16,7 @@ export const AuditStepSchema = Schema.Union(
   AuditClearCacheStepSchema,
   AuditAddCookieStepSchema,
   AuditWaitForTimeStepSchema,
+  AuditWaitForNetworkIdleStepSchema,
 ).annotations({
   title: 'AuditStep',
 });

--- a/libs/audit/domain/src/lib/builder-step-spec.spec.ts
+++ b/libs/audit/domain/src/lib/builder-step-spec.spec.ts
@@ -26,6 +26,33 @@ describe('builder step spec', () => {
       'clearCache',
       'addCookie',
       'waitForTime',
+      'waitForNetworkIdle',
+    ]);
+  });
+
+  it('derives an optional non-negative integer spec for waitForNetworkIdle', () => {
+    const waitForNetworkIdle = deriveBuilderStepSpec(findVariant('waitForNetworkIdle'));
+
+    expect(waitForNetworkIdle.defaultValue).toEqual({
+      type: 'customStep',
+      step: 'waitForNetworkIdle',
+    });
+    expect(waitForNetworkIdle.fields).toEqual([
+      expect.objectContaining({
+        path: 'idleTime',
+        required: false,
+        validation: { integer: true, minimum: 0 },
+      }),
+      expect.objectContaining({
+        path: 'timeout',
+        required: false,
+        validation: { integer: true, minimum: 0 },
+      }),
+      expect.objectContaining({
+        path: 'concurrency',
+        required: false,
+        validation: { integer: true, minimum: 0 },
+      }),
     ]);
   });
 

--- a/libs/audit/domain/src/lib/custom-audit-step-type.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step-type.ts
@@ -2,4 +2,5 @@ export const AUDIT_CUSTOM_STEP_TYPE = {
   CLEAR_CACHE: 'clearCache',
   ADD_COOKIE: 'addCookie',
   WAIT_FOR_TIME: 'waitForTime',
+  WAIT_FOR_NETWORK_IDLE: 'waitForNetworkIdle',
 } as const;

--- a/libs/audit/domain/src/lib/custom-audit-step.ts
+++ b/libs/audit/domain/src/lib/custom-audit-step.ts
@@ -23,6 +23,12 @@ export const WaitForTimeParametersSchema = Schema.Struct({
   seconds: Schema.Number.pipe(Schema.int(), Schema.between(1, 60)),
 });
 
+export const WaitForNetworkIdleParametersSchema = Schema.Struct({
+  idleTime: Schema.optional(Schema.NonNegativeInt),
+  timeout: Schema.optional(Schema.NonNegativeInt),
+  concurrency: Schema.optional(Schema.NonNegativeInt),
+});
+
 export const AuditClearCacheStepSchema = Schema.Struct({
   type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE)),
@@ -38,6 +44,12 @@ export const AuditWaitForTimeStepSchema = Schema.Struct({
   type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME)),
   ...WaitForTimeParametersSchema.fields,
+});
+
+export const AuditWaitForNetworkIdleStepSchema = Schema.Struct({
+  type: AuditStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  step: AppAuditCustomStepTypeSchema.pipe(Schema.pickLiteral(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE)),
+  ...WaitForNetworkIdleParametersSchema.fields,
 });
 
 const ReplayAuditCustomStepWithoutFlagsSchema = Schema.Struct({
@@ -56,6 +68,12 @@ const ReplayAuditWaitForTimeStepSchema = Schema.Struct({
   type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
   name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME),
   parameters: WaitForTimeParametersSchema,
+});
+
+const ReplayAuditWaitForNetworkIdleStepSchema = Schema.Struct({
+  type: PuppeteerReplayStepTypeSchema.pipe(Schema.pickLiteral(PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP)),
+  name: Schema.Literal(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE),
+  parameters: WaitForNetworkIdleParametersSchema,
 });
 
 const AuditClearCacheRunnerStepSchema = Schema.transform(
@@ -120,16 +138,40 @@ const AuditWaitForTimeRunnerStepSchema = Schema.transform(
   },
 );
 
+const AuditWaitForNetworkIdleRunnerStepSchema = Schema.transform(
+  AuditWaitForNetworkIdleStepSchema,
+  ReplayAuditWaitForNetworkIdleStepSchema,
+  {
+    strict: true,
+    decode: ({ idleTime, timeout, concurrency }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+      parameters: {
+        ...(idleTime === undefined ? {} : { idleTime }),
+        ...(timeout === undefined ? {} : { timeout }),
+        ...(concurrency === undefined ? {} : { concurrency }),
+      },
+    }),
+    encode: ({ parameters }) => ({
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+      ...parameters,
+    }),
+  },
+);
+
 export const ReplayAuditCustomStepSchema = Schema.Union(
   Schema.typeSchema(AuditClearCacheRunnerStepSchema),
   Schema.typeSchema(AuditAddCookieRunnerStepSchema),
   Schema.typeSchema(AuditWaitForTimeRunnerStepSchema),
+  Schema.typeSchema(AuditWaitForNetworkIdleRunnerStepSchema),
 );
 
 export const AuditCustomRunnerStepSchema = Schema.Union(
   AuditClearCacheRunnerStepSchema,
   AuditAddCookieRunnerStepSchema,
   AuditWaitForTimeRunnerStepSchema,
+  AuditWaitForNetworkIdleRunnerStepSchema,
 );
 
 export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefinition[] = [
@@ -159,6 +201,14 @@ export const AuditCustomBuilderStepVariants: readonly BuilderStepVariantDefiniti
       type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
       step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
       seconds: 1,
+    },
+  },
+  {
+    id: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+    schema: AuditWaitForNetworkIdleStepSchema,
+    defaultValue: {
+      type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
     },
   },
 ];

--- a/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/components/audit-builder-form.spec.ts
@@ -158,6 +158,23 @@ describe('StepFormGroup', () => {
     expect(formGroup.optionalFields(formGroup.spec.fields, formGroup)).toEqual([]);
   });
 
+  it('selecting waitForNetworkIdle produces a zero-configuration step with optional settings', () => {
+    const formGroup = new StepFormGroup({ type: '' });
+
+    formGroup.resetStepControls(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE);
+
+    expect(formGroup.getRawValue()).toEqual({
+      type: 'customStep',
+      step: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+    });
+    expect(formGroup.visibleFields(formGroup.spec.fields, formGroup)).toEqual([]);
+    expect(formGroup.optionalFields(formGroup.spec.fields, formGroup).map((field) => field.path)).toEqual([
+      'idleTime',
+      'timeout',
+      'concurrency',
+    ]);
+  });
+
   it('does not add or remove steps while the root audit form is disabled', () => {
     const auditForm = new AuditFormGroup({
       title: 'Checkout audit',

--- a/libs/audit/portal/builder/src/lib/step-form.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-form.spec.ts
@@ -57,12 +57,25 @@ describe('BuilderStepFormGroup', () => {
     const navigate = createForm('navigate');
     const click = createForm('click');
     const waitForTime = createForm(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME);
+    const waitForNetworkIdle = createForm(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE);
     const selectorsField = expectArrayField(findField(click.spec.fields, 'selectors'));
 
     const expressionControl = waitForExpression.get('expression');
     const urlControl = navigate.get('url');
     const offsetXControl = click.get('offsetX');
     const secondsControl = waitForTime.get('seconds');
+
+    for (const field of waitForNetworkIdle.spec.fields) {
+      waitForNetworkIdle.addOptionalField(waitForNetworkIdle, field);
+      const control = waitForNetworkIdle.get(field.path);
+
+      control?.setValue(-1);
+      expect(control?.hasError('min')).toBe(true);
+      control?.setValue(1.5);
+      expect(control?.hasError('integer')).toBe(true);
+      control?.setValue(0);
+      expect(control?.valid).toBe(true);
+    }
 
     expect(expressionControl?.hasError('required')).toBe(true);
 

--- a/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.spec.ts
@@ -63,7 +63,30 @@ describe('step presentation registry', () => {
         AUDIT_CUSTOM_STEP_TYPE.CLEAR_CACHE,
         AUDIT_CUSTOM_STEP_TYPE.ADD_COOKIE,
         AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME,
+        AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
       ],
+    });
+  });
+
+  it('presents waitForNetworkIdle settings with the agreed labels and descriptions', () => {
+    expect(getStepPresentation(AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE)).toEqual({
+      group: 'Custom Steps',
+      icon: 'puppeteer-badge',
+      label: 'Wait For Network Idle',
+      fields: {
+        idleTime: {
+          label: 'Idle Time (ms)',
+          description: 'Duration network activity must stay within the allowed concurrency; Puppeteer default: 500 ms.',
+        },
+        timeout: {
+          label: 'Timeout (ms)',
+          description: 'Maximum wait; defaults to the audit timeout; 0 disables the timeout.',
+        },
+        concurrency: {
+          label: 'Allowed Concurrent Requests',
+          description: 'Maximum active request count still considered idle; Puppeteer default: 0.',
+        },
+      },
     });
   });
 

--- a/libs/audit/portal/builder/src/lib/step-presentation.ts
+++ b/libs/audit/portal/builder/src/lib/step-presentation.ts
@@ -96,6 +96,23 @@ export const AUDIT_BUILDER_STEP_PRESENTATION_REGISTRY = {
       },
     },
   },
+  waitForNetworkIdle: {
+    label: 'Wait For Network Idle',
+    fields: {
+      idleTime: {
+        label: 'Idle Time (ms)',
+        description: 'Duration network activity must stay within the allowed concurrency; Puppeteer default: 500 ms.',
+      },
+      timeout: {
+        label: 'Timeout (ms)',
+        description: 'Maximum wait; defaults to the audit timeout; 0 disables the timeout.',
+      },
+      concurrency: {
+        label: 'Allowed Concurrent Requests',
+        description: 'Maximum active request count still considered idle; Puppeteer default: 0.',
+      },
+    },
+  },
 } as const satisfies Partial<Record<string, StepPresentationOverride>>;
 
 export const getStepPresentation = (variantId: string): StepPresentation => {

--- a/libs/audit/runner/src/lib/audit/process-audit.ts
+++ b/libs/audit/runner/src/lib/audit/process-audit.ts
@@ -35,7 +35,7 @@ export const runAudit = Effect.fn((audit: Audit) =>
       startFlow(page, { name: audit.title, config: runnerDeviceConfiguration.lighthousePreset }),
     ).pipe(Effect.withSpan('runner.audit.startFlow'));
 
-    const runnerExtension = new UserFlowRunnerExtension(browser, page, flow);
+    const runnerExtension = new UserFlowRunnerExtension(browser, page, flow, { timeout: audit.timeout ?? 30_000 });
 
     yield* Effect.tryPromise({
       try: () => createRunner(replayScript, runnerExtension).then((runner) => runner.run()),

--- a/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.spec.ts
@@ -19,10 +19,11 @@ const createPage = (cdpClient = createCdpClient()) =>
   ({
     createCDPSession: vi.fn().mockResolvedValue(cdpClient),
     setCookie: vi.fn().mockResolvedValue(undefined),
+    waitForNetworkIdle: vi.fn().mockResolvedValue(undefined),
   }) as unknown as Page;
 
-const createExtension = (flow: UserFlow, page: Page = createPage()) =>
-  new UserFlowRunnerExtension({} as never, page, flow);
+const createExtension = (flow: UserFlow, page: Page = createPage(), timeout?: number) =>
+  new UserFlowRunnerExtension({} as never, page, flow, timeout === undefined ? undefined : { timeout });
 
 describe('UserFlowRunnerExtension', () => {
   it('dispatches each supported custom step exhaustively', async () => {
@@ -163,6 +164,60 @@ describe('UserFlowRunnerExtension', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('dispatches waitForNetworkIdle through the current page with audit timeout inheritance', async () => {
+    const page = createPage();
+    const extension = createExtension(createFlow(), page, 12_000);
+
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+        parameters: { idleTime: 750, concurrency: 2 },
+      },
+      {} as never,
+    );
+
+    expect(page.waitForNetworkIdle).toHaveBeenCalledWith({
+      idleTime: 750,
+      concurrency: 2,
+      timeout: 12_000,
+    });
+  });
+
+  it.each([5_000, 0])('lets waitForNetworkIdle step timeout %s override the audit timeout', async (timeout) => {
+    const page = createPage();
+    const extension = createExtension(createFlow(), page, 12_000);
+
+    await extension.runStep(
+      {
+        type: 'customStep',
+        name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+        parameters: { timeout },
+      },
+      {} as never,
+    );
+
+    expect(page.waitForNetworkIdle).toHaveBeenCalledWith({ timeout });
+  });
+
+  it('uses the audit default and propagates waitForNetworkIdle browser failures', async () => {
+    const failure = new Error('network idle failed');
+    const page = createPage();
+    vi.mocked(page.waitForNetworkIdle).mockRejectedValue(failure);
+
+    await expect(
+      createExtension(createFlow(), page).runStep(
+        {
+          type: 'customStep',
+          name: AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE,
+          parameters: {},
+        },
+        {} as never,
+      ),
+    ).rejects.toThrow('network idle failed');
+    expect(page.waitForNetworkIdle).toHaveBeenCalledWith({ timeout: 30_000 });
   });
 
   it('propagates browser failures for clearCache and addCookie custom steps', async () => {

--- a/libs/audit/runner/src/lib/audit/runner-extension.ts
+++ b/libs/audit/runner/src/lib/audit/runner-extension.ts
@@ -23,7 +23,10 @@ export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
     },
   ) {
     super(browser, page, opts);
+    this.auditTimeout = opts?.timeout ?? 30_000;
   }
+
+  private readonly auditTimeout: number;
 
   override async runStep(
     step: Step | typeof ReplayRunnerCustomStepSchema.Type,
@@ -51,6 +54,11 @@ export class UserFlowRunnerExtension extends PuppeteerRunnerExtension {
         return await this.page.setCookie(step.parameters);
       case AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_TIME:
         return await waitForTime(step.parameters.seconds * 1000);
+      case AUDIT_CUSTOM_STEP_TYPE.WAIT_FOR_NETWORK_IDLE:
+        return await this.page.waitForNetworkIdle({
+          ...step.parameters,
+          timeout: step.parameters.timeout ?? this.auditTimeout,
+        });
     }
 
     return assertNever(step);


### PR DESCRIPTION
## Summary

- add the flat `waitForNetworkIdle` persisted audit-step contract and replay transformation
- expose zero-configuration selection plus optional idle time, timeout, and concurrency fields in the audit builder
- delegate execution to Puppeteer's `page.waitForNetworkIdle` with step-over-audit timeout precedence
- add focused domain, builder, and runner coverage, including validation and failure propagation

## Impact

Audits can now wait for a stable network state after navigation or interaction without relying on fixed delays. Existing custom-step behavior is unchanged.

## Validation

- `pnpm exec nx test audit-domain`
- `pnpm exec nx test audit-runner`
- `pnpm exec nx test audit-portal-builder`
- `pnpm exec nx run-many -t lint -p audit-domain audit-runner audit-portal-builder`
- `pnpm exec nx run-many -t build -p audit-domain audit-runner audit-portal-builder`
- `pnpm exec nx effect:diagnostics audit-domain`
- `pnpm exec nx effect:diagnostics audit-runner`

Note: the inferred `typecheck` targets for `audit-domain` and `audit-portal-builder` currently fail before compilation because their existing tsconfigs enable `inlineSources` without `sourceMap`; both production package builds pass.

Closes #176