### PR TITLE
fix(ci): use api migration target

### DIFF
--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -124,7 +124,7 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           DATABASE_MIGRATION_URL: ${{ secrets.DATABASE_MIGRATION_URL }}
-        run: pnpm exec nx run audit-persistence:migrate
+        run: pnpm exec nx run api:migrate
 
       - name: Publish and Deploy API
         env:

--- a/libs/audit/core/persistence/README.md
+++ b/libs/audit/core/persistence/README.md
@@ -23,23 +23,23 @@ Use `DATABASE_MIGRATION_URL` for direct/admin Supabase connections when pooled r
 Build with:
 
 ```bash
-pnpm exec nx run audit-persistence:build
+pnpm exec nx run audit-core-persistence:build
 ```
 
 Test with:
 
 ```bash
-pnpm exec nx run audit-persistence:test
+pnpm exec nx run audit-core-persistence:test
 ```
 
 Generate a migration after schema changes with:
 
 ```bash
-pnpm exec nx run audit-persistence:migrate-generate
+pnpm exec nx run api:migrate-generate
 ```
 
 Apply migrations with:
 
 ```bash
-DATABASE_MIGRATION_URL=postgres://user:password@host:5432/database pnpm exec nx run audit-persistence:migrate
+DATABASE_MIGRATION_URL=postgres://user:password@host:5432/database pnpm exec nx run api:migrate
 ```


### PR DESCRIPTION
## Summary

- run database migrations through the current `api:migrate` Nx target during API deployment
- update audit persistence documentation to use current Nx project and migration target names

## Testing

- `pnpm exec nx run audit-core-persistence:test`
- `pnpm exec nx run audit-core-persistence:lint`
- `pnpm exec prettier --check .github/workflows/deploy-api.yml libs/audit/core/persistence/README.md`
- verified `api:migrate` and `api:migrate-generate` through `nx show project api`