### PR TITLE
fix(effect): resolve v4 runtime regressions

### DIFF
--- a/libs/audit/core/api-runtime/src/lib/runner/LocalRunnerManager.ts
+++ b/libs/audit/core/api-runtime/src/lib/runner/LocalRunnerManager.ts
@@ -27,6 +27,7 @@ const startRunner = Effect.fn('runner.manager.startProcess')(function* (runnerId
     stdout: 'inherit',
     stderr: 'inherit',
     env: { RUNNER_ID: runnerId },
+    extendEnv: true,
   }).pipe(
     Scope.provide(scope),
     Effect.catch((error) => closeScope(scope).pipe(Effect.andThen(Effect.fail(error)))),

--- a/libs/audit/core/domain/src/lib/audit-definition.schema.ts
+++ b/libs/audit/core/domain/src/lib/audit-definition.schema.ts
@@ -10,7 +10,7 @@ const NonNegativeIntFromStringSchema = Schema.NumberFromString.check(
 
 export const AuditTimeoutSchema = Schema.optional(
   Schema.Union([NonNegativeIntSchema, NonNegativeIntFromStringSchema]).annotate({
-    identifier: 'Timeout',
+    identifier: 'AuditTimeout',
   }),
 );
 

--- a/libs/audit/core/domain/src/lib/puppeteer-replay/puppeteer-replay-step.ts
+++ b/libs/audit/core/domain/src/lib/puppeteer-replay/puppeteer-replay-step.ts
@@ -33,7 +33,7 @@ const TimeoutSchema = Schema.optional(
   Schema.Union([
     NonNegativeIntSchema,
     Schema.NumberFromString.check(Schema.isInt(), Schema.isGreaterThanOrEqualTo(0)),
-  ]).annotate({ identifier: 'Timeout' }),
+  ]).annotate({ identifier: 'StepTimeout' }),
 );
 
 const isValidHttpsOrAboutBlankUrl = (value: string): boolean => {

--- a/libs/audit/user-flow/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/user-flow/domain/src/lib/audit.schema.spec.ts
@@ -248,6 +248,10 @@ describe('PuppeteerReplayUserflowRunnerSchema', () => {
 });
 
 describe('UserFlowAuditDefinitionSchema', () => {
+  it('should generate a JSON Schema document without duplicate identifiers', () => {
+    expect(() => Schema.toJsonSchemaDocument(UserFlowAuditDefinitionSchema)).not.toThrow();
+  });
+
   it('should accept valid audit', async () => {
     expect(
       Schema.is(UserFlowAuditDefinitionSchema)({


### PR DESCRIPTION
## Summary

- give audit-level and replay-step timeout schemas unique Effect v4 identifiers
- prevent API startup from failing with `Duplicate identifier: "Timeout"`
- preserve the inherited process environment when starting a local runner so `pnpm` remains discoverable on `PATH`
- add a JSON Schema generation regression test

Follow-up to #200 and the Effect v4 migration tracked by #165.

## Testing

- `pnpm exec nx test audit-core-domain`
- `pnpm exec nx test audit-user-flow-domain`
- `pnpm exec nx test audit-core-api-runtime`
- `pnpm exec nx build api --configuration=production`
- `pnpm exec nx run api:effect:diagnostics`
- `pnpm exec nx run audit-core-api-runtime:effect:diagnostics`
- production-mode local smoke test: `GET /api/health` returned 200
- production-mode local smoke test: `POST /api/audits/user-flow/schedule` returned 200 with an audit ID