### PR TITLE
test(portal): cover real user-flow audits

### DIFF
--- a/apps/portal-e2e/e2e/app.cy.ts
+++ b/apps/portal-e2e/e2e/app.cy.ts
@@ -15,7 +15,7 @@ const waitForBackend = (attempts = 30): Cypress.Chainable => {
     });
 };
 
-const waitForAuditResult = (auditId: string, attempts = 180): Cypress.Chainable => {
+const waitForAuditResult = (auditId: string, attempts = 120): Cypress.Chainable => {
   return cy
     .request({
       url: `/api/audits/user-flow/${auditId}/result`,
@@ -23,10 +23,15 @@ const waitForAuditResult = (auditId: string, attempts = 180): Cypress.Chainable 
     })
     .then((response) => {
       if (response.status === 200 && response.body?.status === 'SUCCESS') return response;
+      if (response.status === 200 && response.body?.status === 'FAILURE') {
+        throw new Error(`Audit failed for ${auditId}: ${JSON.stringify(response.body)}`);
+      }
       if (attempts <= 1) {
         throw new Error(`Audit result not ready for ${auditId}`);
       }
-      return Cypress.Promise.delay(1000).then(() => waitForAuditResult(auditId, attempts - 1));
+      // The result endpoint is polled with a deliberate backoff while the real runner executes the audit.
+      // eslint-disable-next-line cypress/no-unnecessary-waiting
+      return cy.wait(5000).then(() => waitForAuditResult(auditId, attempts - 1));
     });
 };
 
@@ -37,13 +42,13 @@ describe('portal', () => {
     getAuditBuilder().should('be.visible');
   });
 
-  it('should submit an audit', function () {
-    this.timeout(180000);
+  it('runs a real user-flow audit to completion', function () {
+    this.timeout(12 * 60_000);
     waitForBackend();
     cy.intercept('POST', '/api/audits/user-flow/schedule').as('schedule');
 
     cy.get('input[placeholder="Audit Title"]').clear();
-    cy.get('input[placeholder="Audit Title"]').type('E2E Audit');
+    cy.get('input[placeholder="Audit Title"]').type('e2e');
 
     cy.get('ui-audit-builder-step')
       .first()
@@ -58,18 +63,22 @@ describe('portal', () => {
       .within(() => {
         cy.contains('mat-label', 'Url').closest('mat-form-field').find('input').as('urlInput');
         cy.get('@urlInput').clear();
-        cy.get('@urlInput').type('https://example.com');
+        cy.get('@urlInput').type('https://deep-blue.io');
       });
 
     cy.get('button.submit-btn').should('be.enabled').click();
 
     cy.wait('@schedule', { timeout: 20000 }).then(({ request, response }) => {
-      expect(request.body?.title).to.equal('E2E Audit');
+      expect(request.body?.title).to.equal('e2e');
+      expect(request.body?.steps?.[1]?.url).to.equal('https://deep-blue.io');
       expect(response?.statusCode).to.equal(200);
       expect(response?.body?.auditId).to.be.a('string');
-      return waitForAuditResult(response?.body?.auditId);
+      return waitForAuditResult(response?.body?.auditId).then((result) => {
+        expect(result.body?.status).to.equal('SUCCESS');
+      });
     });
 
-    cy.get('ui-audit-summary', { timeout: 20000 }).should('be.visible');
+    cy.location('pathname', { timeout: 30_000 }).should('match', /^\/audits\/user-flow\/[0-9a-f-]+$/);
+    cy.get('ui-audit-summary', { timeout: 30_000 }).should('be.visible');
   });
 });

--- a/libs/audit/user-flow/domain/src/lib/audit.schema.spec.ts
+++ b/libs/audit/user-flow/domain/src/lib/audit.schema.spec.ts
@@ -4,8 +4,38 @@ import { it } from '@effect/vitest';
 import { AUDIT_CUSTOM_STEP_TYPE } from '@app-speed/audit/core/domain';
 import { LIGHTHOUSE_AUDIT_STEP_TYPE } from './lighthouse-userflow/lighthouse-userflow-step-type';
 import { UserFlowAuditDefinitionSchema, PuppeteerReplayUserflowRunnerSchema } from './audit.schema';
+import { ReplayUserflowStepSchema } from './lighthouse-userflow/lighthouse-userflow-step';
 
 describe('PuppeteerReplayUserflowRunnerSchema', () => {
+  it('decodes a persisted navigation sequence into replay steps', () => {
+    const recording = JSON.parse(
+      JSON.stringify({
+        title: 'e2e',
+        device: 'mobile',
+        steps: [
+          { type: 'customStep', step: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION, name: 'Initial Navigation' },
+          { type: 'navigate', url: 'https://deep-blue.io' },
+          { type: 'customStep', step: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION },
+        ],
+      }),
+    );
+
+    const apiDecoded = Schema.decodeUnknownSync(UserFlowAuditDefinitionSchema)(recording);
+    expect(apiDecoded.steps).toEqual(recording.steps);
+    const persisted = JSON.parse(JSON.stringify(apiDecoded));
+    const audit = Schema.decodeUnknownSync(UserFlowAuditDefinitionSchema)(persisted);
+
+    const replay = Schema.decodeUnknownSync(PuppeteerReplayUserflowRunnerSchema)(audit);
+
+    const parsedReplay = JSON.parse(JSON.stringify(replay));
+
+    expect(parsedReplay.steps[2]).toEqual({
+      type: 'customStep',
+      name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
+    });
+    expect(() => Schema.decodeUnknownSync(ReplayUserflowStepSchema)(parsedReplay.steps[2])).not.toThrow();
+  });
+
   it('should decode to replay schema', () => {
     const recording = {
       title: 'Stub audit title',

--- a/libs/audit/user-flow/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.ts
+++ b/libs/audit/user-flow/domain/src/lib/lighthouse-userflow/lighthouse-userflow-step.ts
@@ -78,13 +78,13 @@ const UserflowStartNavigationRunnerStepSchema = UserflowStartNavigationStepSchem
     Schema.Struct({
       type: ReplayUserflowStepWithFlagsSchema.fields.type,
       name: Schema.Literal(LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION),
-      parameters: Schema.UndefinedOr(Schema.Struct({ name: Schema.String })),
+      parameters: Schema.optional(Schema.Struct({ name: Schema.String })),
     }),
     SchemaTransformation.transform({
       decode: ({ name }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_NAVIGATION,
-        parameters: name ? { name } : undefined,
+        ...(name ? { parameters: { name } } : {}),
       }),
       encode: ({ parameters }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
@@ -100,13 +100,13 @@ const UserflowStartTimespanRunnerStepSchema = UserflowStartTimespanStepSchema.pi
     Schema.Struct({
       type: ReplayUserflowStepWithFlagsSchema.fields.type,
       name: Schema.Literal(LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN),
-      parameters: Schema.UndefinedOr(Schema.Struct({ name: Schema.String })),
+      parameters: Schema.optional(Schema.Struct({ name: Schema.String })),
     }),
     SchemaTransformation.transform({
       decode: ({ name }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.START_TIMESPAN,
-        parameters: name ? { name } : undefined,
+        ...(name ? { parameters: { name } } : {}),
       }),
       encode: ({ parameters }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
@@ -122,13 +122,13 @@ const UserflowSnapshotRunnerStepSchema = UserflowSnapshotStepSchema.pipe(
     Schema.Struct({
       type: ReplayUserflowStepWithFlagsSchema.fields.type,
       name: Schema.Literal(LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT),
-      parameters: Schema.UndefinedOr(Schema.Struct({ name: Schema.String })),
+      parameters: Schema.optional(Schema.Struct({ name: Schema.String })),
     }),
     SchemaTransformation.transform({
       decode: ({ name }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.SNAPSHOT,
-        parameters: name ? { name } : undefined,
+        ...(name ? { parameters: { name } } : {}),
       }),
       encode: ({ parameters }) => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
@@ -150,13 +150,12 @@ const UserflowEndNavigationRunnerStepSchema = UserflowEndNavigationStepSchema.pi
     Schema.Struct({
       type: ReplayUserflowStepWithoutFlagsSchema.fields.type,
       name: Schema.Literal(LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION),
-      parameters: Schema.Undefined,
+      parameters: ReplayUserflowStepWithoutFlagsSchema.fields.parameters,
     }),
     SchemaTransformation.transform({
       decode: () => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_NAVIGATION,
-        parameters: undefined,
       }),
       encode: () => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
@@ -171,13 +170,12 @@ const UserflowEndTimespanRunnerStepSchema = UserflowEndTimespanStepSchema.pipe(
     Schema.Struct({
       type: ReplayUserflowStepWithoutFlagsSchema.fields.type,
       name: Schema.Literal(LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN),
-      parameters: Schema.Undefined,
+      parameters: ReplayUserflowStepWithoutFlagsSchema.fields.parameters,
     }),
     SchemaTransformation.transform({
       decode: () => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,
         name: LIGHTHOUSE_AUDIT_STEP_TYPE.END_TIMESPAN,
-        parameters: undefined,
       }),
       encode: () => ({
         type: PUPPETEER_REPLAY_CUSTOM_STEP_TYPE.CUSTOM_STEP,


### PR DESCRIPTION
## Summary

- exercise a real localhost user-flow audit from the portal with `e2e` and `https://deep-blue.io`
- poll until the audit succeeds and verify the result route and summary
- accept replay custom steps after Puppeteer removes undefined parameters
- add a regression test for the persisted and JSON-cleaned replay shape

## Root cause

The Effect v4 replay schemas required `parameters: undefined`. Puppeteer Replay JSON-cleans recordings before execution, removing those properties and causing valid parameterless steps such as `endNavigation` to fail schema decoding.

No matching migration or replay-decode issue was found to link.

## Validation

- `pnpm exec nx e2e portal-e2e --spec=apps/portal-e2e/e2e/app.cy.ts --browser=chrome`
- `pnpm exec nx test audit-user-flow-domain`
- `pnpm exec nx test audit-user-flow-runner`
- `pnpm exec nx lint portal-e2e`
- `pnpm exec nx lint audit-user-flow-domain`
- `pnpm exec nx build portal`
