### PR TITLE
fix(audit): restore user-flow audit forking

### DIFF
--- a/apps/api/integration/audit.integration.ts
+++ b/apps/api/integration/audit.integration.ts
@@ -56,6 +56,8 @@ describe('Audit', () => {
     const findResponse = await fetch(`${USER_FLOW_API_ENDPOINT}${scheduleResponse.auditId}`).then((r) => r.json());
 
     expect(findResponse).toHaveProperty('status', 'SCHEDULED');
+    expect(findResponse).toHaveProperty('audit');
+    expect(findResponse.audit).toEqual(MOCK_AUDIT);
   });
 
   it('should watch audit', async () => {

--- a/apps/portal-e2e/e2e/audit-user-flow.cy.ts
+++ b/apps/portal-e2e/e2e/audit-user-flow.cy.ts
@@ -58,9 +58,13 @@ describe('full local audit system', () => {
     });
 
     cy.get('[data-testid="audit-progress-status"]', { timeout: 30_000 }).should('be.visible');
+    cy.get('[data-testid="audit-builder-card"]').should('be.visible').and('have.class', 'audit-card--readonly');
+    cy.get('input[name="audit title"]').should('be.disabled');
+    cy.contains('button', 'Fork').should('not.exist');
     cy.wait('@auditResult', { requestTimeout: 240_000, responseTimeout: 240_000 })
       .its('response.body.status')
       .should('equal', 'SUCCESS');
+    cy.contains('button', 'Fork', { timeout: 240_000 }).should('be.enabled');
     cy.get('ui-audit-summary', { timeout: 240_000 }).should('be.visible');
     cy.get('ui-audit-summary .summary-title').should('have.length.greaterThan', 0);
     cy.get('ui-audit-summary .score-container').should('be.visible').and('not.be.empty');

--- a/libs/audit/user-flow/api-contract/src/index.ts
+++ b/libs/audit/user-flow/api-contract/src/index.ts
@@ -3,12 +3,25 @@ import { Schema } from 'effect';
 
 import { UserFlowAuditDefinitionSchema } from '@app-speed/audit/user-flow/domain';
 import {
-  findByIdEndpoint,
+  AuditId,
+  AuditNotFoundError,
+  AuditRunStatusSchema,
   historyEndpoint,
   reportByIdEndpoint,
   resultByIdEndpoint,
   watchByIdEndpoint,
 } from '@app-speed/audit/core/api-contract';
+
+export { AuditId };
+
+export const findUserFlowAuditByIdEndpoint = HttpApiEndpoint.get('findUserFlowAuditById', '/:id', {
+  params: { id: AuditId },
+  success: Schema.Struct({
+    status: AuditRunStatusSchema,
+    audit: UserFlowAuditDefinitionSchema,
+  }),
+  error: [HttpApiError.BadRequestNoContent, AuditNotFoundError],
+});
 
 export const scheduleUserFlowAuditEndpoint = HttpApiEndpoint.post('scheduleUserFlowAudit', '/schedule', {
   payload: UserFlowAuditDefinitionSchema,
@@ -21,7 +34,7 @@ export const scheduleUserFlowAuditEndpoint = HttpApiEndpoint.post('scheduleUserF
 
 export class UserFlowAuditApiGroup extends HttpApiGroup.make('userFlowAudit')
   .add(scheduleUserFlowAuditEndpoint)
-  .add(findByIdEndpoint)
+  .add(findUserFlowAuditByIdEndpoint)
   .add(watchByIdEndpoint)
   .add(resultByIdEndpoint)
   .add(reportByIdEndpoint)

--- a/libs/audit/user-flow/api-runtime/src/lib/Http.ts
+++ b/libs/audit/user-flow/api-runtime/src/lib/Http.ts
@@ -70,10 +70,16 @@ export const UserFlowAuditGroupLive = HttpApiBuilder.group(UserFlowApi, 'userFlo
         ),
       )
       .handle(
-        'findById',
+        'findUserFlowAuditById',
         Effect.fn('api.userFlowAudit.findById')((request) =>
-          requireUserFlowRun(request.params.id).pipe(
-            Effect.map((run) => ({ status: run.status })),
+          Effect.gen(function* () {
+            const run = yield* requireUserFlowRun(request.params.id);
+            const audit = yield* userFlowRepo.getDefinition(run.templateId);
+            if (audit === null) {
+              return yield* new AuditNotFoundError({ id: request.params.id });
+            }
+            return { status: run.status, audit };
+          }).pipe(
             Effect.catchTag('QueryError', () => new HttpApiError.BadRequest()),
             Effect.catchTag('SchemaError', () => new HttpApiError.BadRequest()),
           ),

--- a/libs/audit/user-flow/feature-builder/src/lib/audit.routes.spec.ts
+++ b/libs/audit/user-flow/feature-builder/src/lib/audit.routes.spec.ts
@@ -1,6 +1,16 @@
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter, RouterOutlet, withComponentInputBinding } from '@angular/router';
+import { RouterTestingHarness } from '@angular/router/testing';
+import { ApiClient, AuditProgressService } from '@app-speed/audit/user-flow/portal-data-access';
+import { BehaviorSubject, of } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
 import { auditBuilderRoutes } from './audit.routes';
+import { DEFAULT_AUDIT_DETAILS } from './audit-details';
+import { AuditResultPageComponent } from './feature/audit-result-page.component';
 import { BuilderComponent } from './feature/builder.component';
 
 describe('auditBuilderRoutes', () => {
@@ -9,11 +19,85 @@ describe('auditBuilderRoutes', () => {
     expect(auditBuilderRoutes.at(-1)?.component).toBe(BuilderComponent);
   });
 
-  it('loads results through the user-flow viewer feature', async () => {
+  it('uses the result shell for persisted user-flow audits', () => {
     const resultRoute = auditBuilderRoutes.find((route) => route.path === ':id');
-    const childRoutes = await resultRoute?.loadChildren?.();
 
-    expect(Array.isArray(childRoutes)).toBe(true);
-    expect(childRoutes).toHaveLength(1);
+    expect(resultRoute?.component).toBe(AuditResultPageComponent);
+  });
+
+  it('keeps the submitted audit visible and read-only while it runs', async () => {
+    const stageName$ = new BehaviorSubject<'running'>('running');
+
+    await TestBed.configureTestingModule({
+      imports: [RouterOutlet],
+      providers: [
+        provideNoopAnimations(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: 'audits/user-flow', children: auditBuilderRoutes }], withComponentInputBinding()),
+        {
+          provide: AuditProgressService,
+          useValue: {
+            stageName$,
+            queuePosition$: new BehaviorSubject<number | null>(null),
+            watchAudit: vi.fn(),
+          },
+        },
+        {
+          provide: ApiClient,
+          useValue: {
+            findAudit: () => of({ status: 'IN_PROGRESS', audit: DEFAULT_AUDIT_DETAILS }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/audits/user-flow/run-123');
+    await harness.fixture.whenStable();
+
+    const root: HTMLElement = harness.fixture.nativeElement;
+    const auditCard = root.querySelector('[data-testid="audit-builder-card"]');
+
+    expect(auditCard?.classList.contains('audit-card--readonly')).toBe(true);
+    expect(root.querySelector<HTMLInputElement>('input[name="audit title"]')?.disabled).toBe(true);
+    expect(root.textContent).not.toContain('Fork');
+  });
+
+  it('offers to fork the persisted audit after it completes', async () => {
+    const stageName$ = new BehaviorSubject<'running' | 'done'>('running');
+
+    await TestBed.configureTestingModule({
+      imports: [RouterOutlet],
+      providers: [
+        provideNoopAnimations(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([{ path: 'audits/user-flow', children: auditBuilderRoutes }], withComponentInputBinding()),
+        {
+          provide: AuditProgressService,
+          useValue: {
+            stageName$,
+            queuePosition$: new BehaviorSubject<number | null>(null),
+            watchAudit: vi.fn(),
+          },
+        },
+        {
+          provide: ApiClient,
+          useValue: {
+            findAudit: () => of({ status: 'COMPLETE', audit: DEFAULT_AUDIT_DETAILS }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const harness = await RouterTestingHarness.create();
+    await harness.navigateByUrl('/audits/user-flow/run-123');
+
+    stageName$.next('done');
+    await harness.fixture.whenStable();
+
+    const root: HTMLElement = harness.fixture.nativeElement;
+    expect(root.textContent).toContain('Fork');
   });
 });

--- a/libs/audit/user-flow/feature-builder/src/lib/audit.routes.ts
+++ b/libs/audit/user-flow/feature-builder/src/lib/audit.routes.ts
@@ -4,6 +4,7 @@ import { BuilderComponent } from './feature/builder.component';
 import { provideState } from '@ngrx/store';
 import { auditBuilderFeature } from './feature/builder.state';
 import { provideBuilderEffects } from './feature/builder.effects';
+import { AuditResultPageComponent } from './feature/audit-result-page.component';
 
 const provideAuditBuilderRoute = () => [
   provideState(auditBuilderFeature),
@@ -14,7 +15,8 @@ const provideAuditBuilderRoute = () => [
 export const auditBuilderRoutes: Routes = [
   {
     path: ':id',
-    loadChildren: () => import('@app-speed/audit/user-flow/feature-viewer').then((m) => m.userFlowAuditViewerRoutes),
+    component: AuditResultPageComponent,
+    providers: [provideAuditBuilderIcons()],
   },
   {
     path: '',

--- a/libs/audit/user-flow/feature-builder/src/lib/components/audit-builder.component.spec.ts
+++ b/libs/audit/user-flow/feature-builder/src/lib/components/audit-builder.component.spec.ts
@@ -56,6 +56,20 @@ describe('AuditBuilderComponent', () => {
     expect(submitAudit).not.toHaveBeenCalled();
   });
 
+  it('emits a fork request from the read-only Fork action', async () => {
+    const forked = vi.fn();
+    const builderFixture = await renderBuilder({ modifying: false, primaryAction: 'fork' });
+    builderFixture.componentInstance.forked.subscribe(forked);
+
+    const forkButton = builderFixture.nativeElement.querySelector('button.submit-btn');
+    expect(forkButton).toBeInstanceOf(HTMLButtonElement);
+    if (!(forkButton instanceof HTMLButtonElement)) return;
+    forkButton.click();
+    await builderFixture.whenStable();
+
+    expect(forked).toHaveBeenCalledOnce();
+  });
+
   it('does not emit a submit while an audit request is already in flight', async () => {
     const submitAudit = vi.fn();
     const builderFixture = await renderBuilder({

--- a/libs/audit/user-flow/feature-builder/src/lib/feature/audit-result-page.component.ts
+++ b/libs/audit/user-flow/feature-builder/src/lib/feature/audit-result-page.component.ts
@@ -1,0 +1,86 @@
+import { ChangeDetectionStrategy, Component, computed, inject, input } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Router } from '@angular/router';
+import { catchError, map, of, startWith, switchMap } from 'rxjs';
+
+import { UserFlowAuditPageComponent } from '@app-speed/audit/user-flow/feature-viewer';
+import { ApiClient, AuditProgressService } from '@app-speed/audit/user-flow/portal-data-access';
+
+import type { AuditDetails } from '../audit-details';
+import { AuditBuilderComponent } from '../components/audit-builder.component';
+
+type AuditLoadState =
+  | { status: 'loading' }
+  | { status: 'loaded'; audit: AuditDetails }
+  | { status: 'failed'; message: string };
+
+const INITIAL_AUDIT_LOAD_STATE: AuditLoadState = { status: 'loading' };
+
+@Component({
+  selector: 'user-flow-audit-result-page',
+  imports: [AuditBuilderComponent, UserFlowAuditPageComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @switch (auditLoadState().status) {
+      @case ('loaded') {
+        @if (loadedAudit(); as audit) {
+          <ui-audit-builder
+            [initialAudit]="audit"
+            [modifying]="false"
+            [primaryAction]="primaryAction()"
+            [collapseSteps]="true"
+            (forked)="forkAudit(audit)"
+          />
+        }
+      }
+      @case ('failed') {
+        <section data-testid="audit-inline-error" role="alert">{{ loadError() }}</section>
+      }
+    }
+
+    <user-flow-audit-page [id]="id()" />
+  `,
+})
+export class AuditResultPageComponent {
+  readonly id = input.required<string>();
+  private readonly api = inject(ApiClient);
+  private readonly progress = inject(AuditProgressService);
+  private readonly router = inject(Router);
+
+  readonly stage = toSignal(
+    toObservable(this.id).pipe(
+      switchMap((auditId) => {
+        this.progress.watchAudit(auditId);
+        return this.progress.stageName$;
+      }),
+    ),
+    { initialValue: 'scheduling' },
+  );
+  private readonly auditLoadState$ = toObservable(this.id).pipe(
+    switchMap((auditId) =>
+      this.api.findAudit(auditId).pipe(
+        map(({ audit }): AuditLoadState => ({ status: 'loaded', audit })),
+        catchError(() => of<AuditLoadState>({ status: 'failed', message: 'Unable to load this audit.' })),
+        startWith(INITIAL_AUDIT_LOAD_STATE),
+      ),
+    ),
+  );
+  readonly auditLoadState = toSignal(this.auditLoadState$, { initialValue: INITIAL_AUDIT_LOAD_STATE });
+  readonly loadedAudit = computed(() => {
+    const state = this.auditLoadState();
+    return state.status === 'loaded' ? state.audit : null;
+  });
+  readonly loadError = computed(() => {
+    const state = this.auditLoadState();
+    return state.status === 'failed' ? state.message : null;
+  });
+  readonly primaryAction = computed<'fork' | 'none'>(() =>
+    this.stage() === 'done' || this.stage() === 'failed' ? 'fork' : 'none',
+  );
+
+  forkAudit(audit: AuditDetails): void {
+    void this.router.navigate(['/audits/user-flow'], {
+      queryParams: { ['audit-details']: JSON.stringify(audit) },
+    });
+  }
+}

--- a/libs/audit/user-flow/feature-viewer/src/index.ts
+++ b/libs/audit/user-flow/feature-viewer/src/index.ts
@@ -1,4 +1,5 @@
 export { AuditViewerContainer } from './lib/page/audit-viewer.container';
+export { UserFlowAuditPageComponent } from './lib/page/user-flow-audit-page.component';
 export { userFlowAuditViewerRoutes } from './lib/audit.routes';
 export { AuditSummaryComponent, type AuditSummary } from './lib/summary/audit-summary.component';
 export { ViewerDiagnosticComponent } from './lib/diagnostics/viewer-diagnostic.component';

--- a/libs/audit/user-flow/portal-data-access/src/lib/api-client.service.ts
+++ b/libs/audit/user-flow/portal-data-access/src/lib/api-client.service.ts
@@ -5,12 +5,24 @@ import { HttpApiClient } from 'effect/unstable/httpapi';
 import { Effect, ManagedRuntime, Schema } from 'effect';
 
 import { from } from 'rxjs';
-import { UserFlowApi } from '@app-speed/audit/user-flow/api-contract';
+import { AuditId, UserFlowApi } from '@app-speed/audit/user-flow/api-contract';
 import { UserFlowAuditDefinitionSchema } from '@app-speed/audit/user-flow/domain';
 
 @Injectable({ providedIn: 'root' })
 export class ApiClient {
   private readonly runtime = ManagedRuntime.make(FetchHttpClient.layer);
+
+  findAudit(auditId: string) {
+    return from(
+      this.runtime.runPromise(
+        Effect.gen(function* () {
+          const apiClient = yield* HttpApiClient.make(UserFlowApi);
+          const id = yield* Schema.decodeUnknownEffect(AuditId)(auditId);
+          return yield* apiClient.userFlowAudit.findUserFlowAuditById({ params: { id } });
+        }),
+      ),
+    );
+  }
 
   scheduleAudit(auditDetails: unknown) {
     return from(


### PR DESCRIPTION
## Summary

- keep the submitted user-flow audit form visible and read-only while an audit runs
- restore the persisted audit definition in the typed user-flow API read model
- show the Fork action after the audit completes or fails while retaining the progress/results viewer
- add route, component, API integration, and end-to-end regression coverage

## Root cause

The execution/results migration replaced the former result-page composition with a viewer-only route and reduced the run lookup to status-only data. The reusable builder still supported read-only and Fork modes, but nothing mounted it and the persisted definition was no longer available to reconstruct it.

## Testing

- `pnpm exec nx test audit-user-flow-feature-builder --runInBand`
- `pnpm exec nx affected -t test --parallel=3`
- `pnpm exec nx affected -t lint --parallel=3`
- `pnpm exec nx run-many -t typecheck -p api portal portal-e2e --parallel=3`
- `pnpm exec nx run-many -t build -p api portal --parallel=2`
- Effect diagnostics for the user-flow API contract and runtime

The full API integration orchestration could not start locally because `APP_SPEED_TEST_DATABASE_URL` is not configured in this environment.